### PR TITLE
Trim whitespace when checking for !squash command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/github-review-helper

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func handleIssueComment(body []byte, git Git, pullRequests PullRequests, reposit
 		return SuccessResponse{"Not a PR. Ignoring."}
 	}
 	switch {
-	case issueComment.Comment == "!squash":
+	case isSquashCommand(issueComment.Comment):
 		return handleSquashCommand(issueComment, git, pullRequests, repositories)
 	case startsWithPlusOne.MatchString(issueComment.Comment):
 		return handlePlusOneComment(issueComment, pullRequests, repositories)

--- a/squash.go
+++ b/squash.go
@@ -8,6 +8,10 @@ import (
 	"github.com/google/go-github/github"
 )
 
+func isSquashCommand(comment string) bool {
+	return strings.TrimSpace(comment) == "!squash"
+}
+
 func handleSquashCommand(issueComment IssueComment, git Git, pullRequests PullRequests, repositories Repositories) Response {
 	pr, errResp := getPR(issueComment, pullRequests)
 	if errResp != nil {


### PR DESCRIPTION
This avoids issues with empty newlines and such after the command.