### PR TITLE
Add !merge command

### DIFF
--- a/github.go
+++ b/github.go
@@ -16,6 +16,10 @@ type Repositories interface {
 	CreateStatus(owner, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error)
 }
 
+type Issues interface {
+	AddLabelsToIssue(owner, repo string, number int, labels []string) ([]github.Label, *github.Response, error)
+}
+
 func setPRHeadStatus(issueable Issueable, status *github.RepoStatus, pullRequests PullRequests, repositories Repositories) *ErrorResponse {
 	pr, errResp := getPR(issueable, pullRequests)
 	if errResp != nil {
@@ -52,4 +56,13 @@ func getCommits(issueable Issueable, pullRequests PullRequests) ([]github.Reposi
 		return nil, &ErrorResponse{err, http.StatusBadGateway, message}
 	}
 	return commits, nil
+}
+
+func addLabel(repository Repository, issueNumber int, label string, issues Issues) *ErrorResponse {
+	_, _, err := issues.AddLabelsToIssue(repository.Owner, repository.Name, issueNumber, []string{label})
+	if err != nil {
+		message := fmt.Sprintf("Failed to set the label %s for issue nr %d", label, issueNumber)
+		return &ErrorResponse{err, http.StatusBadGateway, message}
+	}
+	return nil
 }

--- a/github.go
+++ b/github.go
@@ -8,8 +8,8 @@ import (
 )
 
 type PullRequests interface {
-	Get(owner string, repo string, number int) (*github.PullRequest, *github.Response, error)
-	ListCommits(owner string, repo string, number int, opt *github.ListOptions) ([]github.RepositoryCommit, *github.Response, error)
+	Get(owner, repo string, number int) (*github.PullRequest, *github.Response, error)
+	ListCommits(owner, repo string, number int, opt *github.ListOptions) ([]github.RepositoryCommit, *github.Response, error)
 }
 
 type Repositories interface {

--- a/github.go
+++ b/github.go
@@ -23,6 +23,7 @@ type Repositories interface {
 
 type Issues interface {
 	AddLabelsToIssue(owner, repo string, number int, labels []string) ([]github.Label, *github.Response, error)
+	RemoveLabelForIssue(owner, repo string, number int, label string) (*github.Response, error)
 }
 
 func setPRHeadStatus(issueable Issueable, status *github.RepoStatus, pullRequests PullRequests, repositories Repositories) *ErrorResponse {
@@ -67,6 +68,15 @@ func addLabel(repository Repository, issueNumber int, label string, issues Issue
 	_, _, err := issues.AddLabelsToIssue(repository.Owner, repository.Name, issueNumber, []string{label})
 	if err != nil {
 		message := fmt.Sprintf("Failed to set the label %s for issue #%d", label, issueNumber)
+		return &ErrorResponse{err, http.StatusBadGateway, message}
+	}
+	return nil
+}
+
+func removeLabel(repository Repository, issueNumber int, label string, issues Issues) *ErrorResponse {
+	_, err := issues.RemoveLabelForIssue(repository.Owner, repository.Name, issueNumber, label)
+	if err != nil {
+		message := fmt.Sprintf("Failed to remove the label %s for issue #%d", label, issueNumber)
 		return &ErrorResponse{err, http.StatusBadGateway, message}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func handleIssueComment(body []byte, git Git, pullRequests PullRequests, reposit
 	case isSquashCommand(issueComment.Comment):
 		return handleSquashCommand(issueComment, git, pullRequests, repositories)
 	case isMergeCommand(issueComment.Comment):
-		return handleMergeCommand(issueComment, issues, pullRequests, repositories)
+		return handleMergeCommand(issueComment, issues, pullRequests, repositories, git)
 	case isPlusOneComment.MatchString(issueComment.Comment):
 		return handlePlusOneComment(issueComment, pullRequests, repositories)
 	}

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func handleIssueComment(body []byte, git Git, pullRequests PullRequests, reposit
 	case isSquashCommand(issueComment.Comment):
 		return handleSquashCommand(issueComment, git, pullRequests, repositories)
 	case isMergeCommand(issueComment.Comment):
-		return handleMergeCommand(issueComment, issues)
+		return handleMergeCommand(issueComment, issues, pullRequests)
 	case isPlusOneComment.MatchString(issueComment.Comment):
 		return handlePlusOneComment(issueComment, pullRequests, repositories)
 	}

--- a/main.go
+++ b/main.go
@@ -70,6 +70,8 @@ func handleIssueComment(body []byte, git Git, pullRequests PullRequests, reposit
 	switch {
 	case isSquashCommand(issueComment.Comment):
 		return handleSquashCommand(issueComment, git, pullRequests, repositories)
+	case isMergeCommand(issueComment.Comment):
+		return handleMergeCommand(issueComment)
 	case isPlusOneComment.MatchString(issueComment.Comment):
 		return handlePlusOneComment(issueComment, pullRequests, repositories)
 	}

--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ func handlePullRequestEvent(body []byte, pullRequests PullRequests, repositories
 	pullRequestEvent, err := parsePullRequestEvent(body)
 	if err != nil {
 		return ErrorResponse{err, http.StatusInternalServerError, "Failed to parse the request's body"}
+	} else if !(pullRequestEvent.Action == "opened" || pullRequestEvent.Action == "synchronize") {
+		return SuccessResponse{"PR not opened or synchronized. Ignoring."}
 	}
 	return checkForFixupCommits(pullRequestEvent, pullRequests, repositories)
 }

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func handleIssueComment(body []byte, git Git, pullRequests PullRequests, reposit
 	case isSquashCommand(issueComment.Comment):
 		return handleSquashCommand(issueComment, git, pullRequests, repositories)
 	case isMergeCommand(issueComment.Comment):
-		return handleMergeCommand(issueComment, issues, pullRequests)
+		return handleMergeCommand(issueComment, issues, pullRequests, repositories)
 	case isPlusOneComment.MatchString(issueComment.Comment):
 		return handlePlusOneComment(issueComment, pullRequests, repositories)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	repositoryOwner = "salemove"
+	repositoryName  = "github-review-helper"
+	sshURL          = "git@github.com:salemove/github-review-helper.git"
+	issueNumber     = 7
+)
+
 var _ = Describe("github-review-helper", func() {
 	Describe("/ handler", func() {
 		var (
@@ -110,20 +117,20 @@ var _ = Describe("github-review-helper", func() {
 		var issueCommentEvent = func(comment string) string {
 			return `{
   "issue": {
-    "number": 7,
+    "number": ` + strconv.Itoa(issueNumber) + `,
     "pull_request": {
-      "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
+      "url": "https://api.github.com/repos/` + repositoryOwner + `/` + repositoryName + `/pulls/` + strconv.Itoa(issueNumber) + `"
     }
   },
   "comment": {
     "body": "` + comment + `"
   },
   "repository": {
-    "name": "github-review-helper",
+    "name": "` + repositoryName + `",
     "owner": {
-      "login": "salemove"
+      "login": "` + repositoryOwner + `"
     },
-    "ssh_url": "git@github.com:salemove/github-review-helper.git"
+    "ssh_url": "` + sshURL + `"
   }
 }`
 		}
@@ -166,7 +173,7 @@ var _ = Describe("github-review-helper", func() {
 
 					Context("with GitHub request failing", func() {
 						BeforeEach(func() {
-							pullRequests.On("Get", "salemove", "github-review-helper", 7).Return(nil, nil, errors.New("an error"))
+							pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(nil, nil, errors.New("an error"))
 						})
 
 						It("fails with a gateway error", func() {
@@ -179,7 +186,7 @@ var _ = Describe("github-review-helper", func() {
 						var repo *MockRepo
 
 						BeforeEach(func() {
-							pullRequests.On("Get", "salemove", "github-review-helper", 7).Return(&github.PullRequest{
+							pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(&github.PullRequest{
 								Base: &github.PullRequestBranch{
 									SHA: github.String("1234"),
 									Ref: github.String("master"),
@@ -190,7 +197,7 @@ var _ = Describe("github-review-helper", func() {
 								},
 							}, nil, nil)
 							repo = new(MockRepo)
-							git.On("GetUpdatedRepo", "git@github.com:salemove/github-review-helper.git", "salemove", "github-review-helper").Return(repo, nil)
+							git.On("GetUpdatedRepo", sshURL, repositoryOwner, repositoryName).Return(repo, nil)
 						})
 
 						Context("with autosquash failing", func() {
@@ -199,7 +206,7 @@ var _ = Describe("github-review-helper", func() {
 							})
 
 							It("reports the failure", func() {
-								repositories.On("CreateStatus", "salemove", "github-review-helper", "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
+								repositories.On("CreateStatus", repositoryOwner, repositoryName, "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
 
 								handle()
 
@@ -242,7 +249,7 @@ var _ = Describe("github-review-helper", func() {
 					var itMarksCommitPeerReviewed = func() {
 						Context("with GitHub request failing", func() {
 							BeforeEach(func() {
-								pullRequests.On("Get", "salemove", "github-review-helper", 7).Return(nil, nil, errors.New("an error"))
+								pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(nil, nil, errors.New("an error"))
 							})
 
 							It("fails with a gateway error", func() {
@@ -253,7 +260,7 @@ var _ = Describe("github-review-helper", func() {
 
 						Context("with GitHub request succeeding", func() {
 							BeforeEach(func() {
-								pullRequests.On("Get", "salemove", "github-review-helper", 7).Return(&github.PullRequest{
+								pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(&github.PullRequest{
 									Head: &github.PullRequestBranch{
 										SHA: github.String("1235"),
 										Ref: github.String("feature"),
@@ -262,7 +269,7 @@ var _ = Describe("github-review-helper", func() {
 							})
 
 							It("reports the status", func() {
-								repositories.On("CreateStatus", "salemove", "github-review-helper", "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
+								repositories.On("CreateStatus", repositoryOwner, repositoryName, "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
 
 								handle()
 
@@ -297,16 +304,16 @@ var _ = Describe("github-review-helper", func() {
 			var pullRequestsEvent = func(action string) string {
 				return `{
   "action": "` + action + `",
-  "number": 7,
+  "number": ` + strconv.Itoa(issueNumber) + `,
   "pull_request": {
-    "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
+    "url": "https://api.github.com/repos/` + repositoryOwner + `/` + repositoryName + `/pulls/` + strconv.Itoa(issueNumber) + `"
   },
   "repository": {
-    "name": "github-review-helper",
+    "name": "` + repositoryName + `",
     "owner": {
-      "login": "salemove"
+      "login": "` + repositoryOwner + `"
     },
-    "ssh_url": "git@github.com:salemove/github-review-helper.git"
+    "ssh_url": "` + sshURL + `"
   }
 }`
 			}
@@ -338,7 +345,7 @@ var _ = Describe("github-review-helper", func() {
 					Context("with GitHub request to list commits failing", func() {
 						BeforeEach(func() {
 							var listOptions *github.ListOptions
-							pullRequests.On("ListCommits", "salemove", "github-review-helper", 7, listOptions).Return(nil, nil, errors.New("an error"))
+							pullRequests.On("ListCommits", repositoryOwner, repositoryName, issueNumber, listOptions).Return(nil, nil, errors.New("an error"))
 						})
 
 						It("fails with a gateway error", func() {
@@ -350,7 +357,7 @@ var _ = Describe("github-review-helper", func() {
 					Context("with list of commits from GitHub NOT including fixup commits", func() {
 						BeforeEach(func() {
 							var listOptions *github.ListOptions
-							pullRequests.On("ListCommits", "salemove", "github-review-helper", 7, listOptions).Return([]github.RepositoryCommit{
+							pullRequests.On("ListCommits", repositoryOwner, repositoryName, issueNumber, listOptions).Return([]github.RepositoryCommit{
 								github.RepositoryCommit{
 									Commit: &github.Commit{
 										Message: github.String("Changing things"),
@@ -362,7 +369,7 @@ var _ = Describe("github-review-helper", func() {
 									},
 								},
 							}, nil, nil)
-							pullRequests.On("Get", "salemove", "github-review-helper", 7).Return(&github.PullRequest{
+							pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(&github.PullRequest{
 								Head: &github.PullRequestBranch{
 									SHA: github.String("1235"),
 								},
@@ -370,7 +377,7 @@ var _ = Describe("github-review-helper", func() {
 						})
 
 						It("reports success status to GitHub", func() {
-							repositories.On("CreateStatus", "salemove", "github-review-helper", "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
+							repositories.On("CreateStatus", repositoryOwner, repositoryName, "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
 
 							handle()
 
@@ -384,7 +391,7 @@ var _ = Describe("github-review-helper", func() {
 					Context("with list of commits from GitHub including fixup commits", func() {
 						BeforeEach(func() {
 							var listOptions *github.ListOptions
-							pullRequests.On("ListCommits", "salemove", "github-review-helper", 7, listOptions).Return([]github.RepositoryCommit{
+							pullRequests.On("ListCommits", repositoryOwner, repositoryName, issueNumber, listOptions).Return([]github.RepositoryCommit{
 								github.RepositoryCommit{
 									Commit: &github.Commit{
 										Message: github.String("Changing things"),
@@ -396,7 +403,7 @@ var _ = Describe("github-review-helper", func() {
 									},
 								},
 							}, nil, nil)
-							pullRequests.On("Get", "salemove", "github-review-helper", 7).Return(&github.PullRequest{
+							pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(&github.PullRequest{
 								Head: &github.PullRequestBranch{
 									SHA: github.String("1235"),
 								},
@@ -404,7 +411,7 @@ var _ = Describe("github-review-helper", func() {
 						})
 
 						It("reports pending squash status to GitHub", func() {
-							repositories.On("CreateStatus", "salemove", "github-review-helper", "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
+							repositories.On("CreateStatus", repositoryOwner, repositoryName, "1235", mock.AnythingOfType("*github.RepoStatus")).Return(nil, nil, nil)
 
 							handle()
 

--- a/main_test.go
+++ b/main_test.go
@@ -218,7 +218,7 @@ var _ = Describe("github-review-helper", func() {
 
 						Context("with autosquash failing", func() {
 							BeforeEach(func() {
-								repo.On("RebaseAutosquash", baseSHA, headSHA).Return(errors.New("merge conflict"))
+								repo.On("RebaseAutosquash", baseRef, headSHA).Return(errors.New("merge conflict"))
 							})
 
 							It("reports the failure", func() {
@@ -235,7 +235,7 @@ var _ = Describe("github-review-helper", func() {
 
 						Context("with autosquash succeeding", func() {
 							BeforeEach(func() {
-								repo.On("RebaseAutosquash", baseSHA, headSHA).Return(nil)
+								repo.On("RebaseAutosquash", baseRef, headSHA).Return(nil)
 							})
 
 							It("pushes the squashed changes, reports status", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -154,7 +154,7 @@ var _ = Describe("github-review-helper", func() {
 					})
 				})
 
-				Context("with a !squash comment", func() {
+				Describe("!squash comment", func() {
 					BeforeEach(func() {
 						requestJSON = `{
   "issue": {
@@ -239,7 +239,36 @@ var _ = Describe("github-review-helper", func() {
 					})
 				})
 
-				Context("with a +1 comment", func() {
+				Describe("!merge comment", func() {
+					BeforeEach(func() {
+						requestJSON = `{
+  "issue": {
+    "number": 7,
+    "pull_request": {
+      "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
+    }
+  },
+  "comment": {
+    "body": "!merge"
+  },
+  "repository": {
+    "name": "github-review-helper",
+    "owner": {
+      "login": "salemove"
+    },
+    "ssh_url": "git@github.com:salemove/github-review-helper.git"
+  }
+}`
+						mockSignature()
+					})
+
+					It("succeeds", func() {
+						handle()
+						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+					})
+				})
+
+				Describe("+1 comment", func() {
 					var itMarksCommitPeerReviewed = func() {
 						Context("with GitHub request failing", func() {
 							BeforeEach(func() {

--- a/main_test.go
+++ b/main_test.go
@@ -107,6 +107,27 @@ var _ = Describe("github-review-helper", func() {
 			})
 		})
 
+		var issueCommentEvent = func(comment string) string {
+			return `{
+  "issue": {
+    "number": 7,
+    "pull_request": {
+      "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
+    }
+  },
+  "comment": {
+    "body": "` + comment + `"
+  },
+  "repository": {
+    "name": "github-review-helper",
+    "owner": {
+      "login": "salemove"
+    },
+    "ssh_url": "git@github.com:salemove/github-review-helper.git"
+  }
+}`
+		}
+
 		Context("with a valid signature", func() {
 			var mockSignature func()
 
@@ -126,24 +147,7 @@ var _ = Describe("github-review-helper", func() {
 
 				Context("with an arbitrary comment", func() {
 					BeforeEach(func() {
-						requestJSON = `{
-  "issue": {
-    "number": 7,
-    "pull_request": {
-      "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
-    }
-  },
-  "comment": {
-    "body": "just a simple comment"
-  },
-  "repository": {
-    "name": "github-review-helper",
-    "owner": {
-      "login": "salemove"
-    },
-    "ssh_url": "git@github.com:salemove/github-review-helper.git"
-  }
-}`
+						requestJSON = issueCommentEvent("just a simple comment")
 						mockSignature()
 					})
 
@@ -156,24 +160,7 @@ var _ = Describe("github-review-helper", func() {
 
 				Describe("!squash comment", func() {
 					BeforeEach(func() {
-						requestJSON = `{
-  "issue": {
-    "number": 7,
-    "pull_request": {
-      "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
-    }
-  },
-  "comment": {
-    "body": "!squash"
-  },
-  "repository": {
-    "name": "github-review-helper",
-    "owner": {
-      "login": "salemove"
-    },
-    "ssh_url": "git@github.com:salemove/github-review-helper.git"
-  }
-}`
+						requestJSON = issueCommentEvent("!squash")
 						mockSignature()
 					})
 
@@ -241,24 +228,7 @@ var _ = Describe("github-review-helper", func() {
 
 				Describe("!merge comment", func() {
 					BeforeEach(func() {
-						requestJSON = `{
-  "issue": {
-    "number": 7,
-    "pull_request": {
-      "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
-    }
-  },
-  "comment": {
-    "body": "!merge"
-  },
-  "repository": {
-    "name": "github-review-helper",
-    "owner": {
-      "login": "salemove"
-    },
-    "ssh_url": "git@github.com:salemove/github-review-helper.git"
-  }
-}`
+						requestJSON = issueCommentEvent("!merge")
 						mockSignature()
 					})
 
@@ -306,24 +276,7 @@ var _ = Describe("github-review-helper", func() {
 
 					Context("with +1 at the beginning of the comment", func() {
 						BeforeEach(func() {
-							requestJSON = `{
-	  "issue": {
-		"number": 7,
-		"pull_request": {
-		  "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
-		}
-	  },
-	  "comment": {
-		"body": "+1, awesome job!"
-	  },
-	  "repository": {
-		"name": "github-review-helper",
-		"owner": {
-		  "login": "salemove"
-		},
-		"ssh_url": "git@github.com:salemove/github-review-helper.git"
-	  }
-	}`
+							requestJSON = issueCommentEvent("+1, awesome job!")
 							mockSignature()
 						})
 
@@ -332,24 +285,7 @@ var _ = Describe("github-review-helper", func() {
 
 					Context("with +1 at the end of the comment", func() {
 						BeforeEach(func() {
-							requestJSON = `{
-	  "issue": {
-		"number": 7,
-		"pull_request": {
-		  "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
-		}
-	  },
-	  "comment": {
-		"body": "Looking good! +1"
-	  },
-	  "repository": {
-		"name": "github-review-helper",
-		"owner": {
-		  "login": "salemove"
-		},
-		"ssh_url": "git@github.com:salemove/github-review-helper.git"
-	  }
-	}`
+							requestJSON = issueCommentEvent("Looking good! +1")
 							mockSignature()
 						})
 
@@ -358,21 +294,12 @@ var _ = Describe("github-review-helper", func() {
 				})
 			})
 
-			Describe("pull_request event", func() {
-				BeforeEach(func() {
-					headers["X-Github-Event"] = []string{"pull_request"}
-				})
-
-				Context("with the PR being closed", func() {
-					BeforeEach(func() {
-						requestJSON = `{
-  "action": "closed",
+			var pullRequestsEvent = func(action string) string {
+				return `{
+  "action": "` + action + `",
   "number": 7,
   "pull_request": {
     "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
-  },
-  "comment": {
-    "body": "just a simple comment"
   },
   "repository": {
     "name": "github-review-helper",
@@ -382,6 +309,16 @@ var _ = Describe("github-review-helper", func() {
     "ssh_url": "git@github.com:salemove/github-review-helper.git"
   }
 }`
+			}
+
+			Describe("pull_request event", func() {
+				BeforeEach(func() {
+					headers["X-Github-Event"] = []string{"pull_request"}
+				})
+
+				Context("with the PR being closed", func() {
+					BeforeEach(func() {
+						requestJSON = pullRequestsEvent("closed")
 						mockSignature()
 					})
 
@@ -394,23 +331,7 @@ var _ = Describe("github-review-helper", func() {
 
 				Context("with the PR being synchronized", func() {
 					BeforeEach(func() {
-						requestJSON = `{
-  "action": "synchronize",
-  "number": 7,
-  "pull_request": {
-    "url": "https://api.github.com/repos/salemove/github-review-helper/pulls/7"
-  },
-  "comment": {
-    "body": "just a simple comment"
-  },
-  "repository": {
-    "name": "github-review-helper",
-    "owner": {
-      "login": "salemove"
-    },
-    "ssh_url": "git@github.com:salemove/github-review-helper.git"
-  }
-}`
+						requestJSON = pullRequestsEvent("synchronize")
 						mockSignature()
 					})
 

--- a/main_test.go
+++ b/main_test.go
@@ -196,6 +196,13 @@ var _ = Describe("github-review-helper", func() {
 								Head: &github.PullRequestBranch{
 									SHA: github.String("1235"),
 									Ref: github.String("feature"),
+									Repo: &github.Repository{
+										Owner: &github.User{
+											Login: github.String(repositoryOwner),
+										},
+										Name:   github.String(repositoryName),
+										SSHURL: github.String(sshURL),
+									},
 								},
 							}, nil, nil)
 							repo = new(MockRepo)

--- a/main_test.go
+++ b/main_test.go
@@ -258,7 +258,7 @@ var _ = Describe("github-review-helper", func() {
 					Context("with github request to add the label failing", func() {
 						BeforeEach(func() {
 							issues.
-								On("AddLabelsToIssue", repositoryOwner, repositoryName, issueNumber, []string{"merging"}).
+								On("AddLabelsToIssue", repositoryOwner, repositoryName, issueNumber, []string{MergingLabel}).
 								Return(nil, nil, errors.New("an error"))
 						})
 
@@ -271,7 +271,7 @@ var _ = Describe("github-review-helper", func() {
 					Context("with github request to add the label succeeding", func() {
 						BeforeEach(func() {
 							issues.
-								On("AddLabelsToIssue", repositoryOwner, repositoryName, issueNumber, []string{"merging"}).
+								On("AddLabelsToIssue", repositoryOwner, repositoryName, issueNumber, []string{MergingLabel}).
 								Return(nil, nil, nil)
 						})
 
@@ -293,10 +293,14 @@ var _ = Describe("github-review-helper", func() {
 								pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(&github.PullRequest{
 									Merged: github.Bool(true),
 								}, nil, nil)
+								issues.
+									On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
+									Return(nil, nil, nil)
 							})
 
-							It("succeeds", func() {
+							It("removes the 'merging' label from the PR", func() {
 								handle()
+								issues.AssertExpectations(GinkgoT())
 								Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 							})
 						})
@@ -378,12 +382,16 @@ var _ = Describe("github-review-helper", func() {
 												Merged: github.Bool(true),
 											}, nil, nil).
 											Once()
+										issues.
+											On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
+											Return(nil, nil, nil)
 									})
 
-									It("succeeds", func() {
+									It("removes the 'merging' label from the PR after the merge", func() {
 										handle()
 										pullRequests.AssertNumberOfCalls(GinkgoT(), "Get", 2)
 										pullRequests.AssertNumberOfCalls(GinkgoT(), "Merge", 2)
+										issues.AssertExpectations(GinkgoT())
 										Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 									})
 								})
@@ -421,10 +429,14 @@ var _ = Describe("github-review-helper", func() {
 											Merged: github.Bool(true),
 										}, nil, nil).
 										Once()
+									issues.
+										On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
+										Return(nil, nil, nil)
 								})
 
-								It("succeeds", func() {
+								It("removes the 'merging' label from the PR after the merge", func() {
 									handle()
+									issues.AssertExpectations(GinkgoT())
 									Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 								})
 							})

--- a/main_test.go
+++ b/main_test.go
@@ -462,10 +462,12 @@ var _ = Describe("github-review-helper", func() {
 											mockMergeFailWithConflict()
 										})
 
-										It("retries 3 times and fails with a gateway error", func() {
+										It("retries and fails with a gateway error", func() {
 											handle()
-											pullRequests.AssertNumberOfCalls(GinkgoT(), "Get", 4)
-											pullRequests.AssertNumberOfCalls(GinkgoT(), "Merge", 4)
+
+											// +1 because of the initial attempt
+											pullRequests.AssertNumberOfCalls(GinkgoT(), "Get", MergeRetryLimit+1)
+											pullRequests.AssertNumberOfCalls(GinkgoT(), "Merge", MergeRetryLimit+1)
 											Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 										})
 									})

--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,16 @@ const (
 	issueNumber     = 7
 )
 
+var (
+	repository = &github.Repository{
+		Owner: &github.User{
+			Login: github.String(repositoryOwner),
+		},
+		Name:   github.String(repositoryName),
+		SSHURL: github.String(sshURL),
+	}
+)
+
 var _ = Describe("github-review-helper", func() {
 	Describe("/ handler", func() {
 		var (
@@ -243,19 +253,14 @@ var _ = Describe("github-review-helper", func() {
 					Context("with GitHub request succeeding", func() {
 						pr := &github.PullRequest{
 							Base: &github.PullRequestBranch{
-								SHA: github.String("1234"),
-								Ref: github.String("master"),
+								SHA:  github.String("1234"),
+								Ref:  github.String("master"),
+								Repo: repository,
 							},
 							Head: &github.PullRequestBranch{
-								SHA: github.String("1235"),
-								Ref: github.String("feature"),
-								Repo: &github.Repository{
-									Owner: &github.User{
-										Login: github.String(repositoryOwner),
-									},
-									Name:   github.String(repositoryName),
-									SSHURL: github.String(sshURL),
-								},
+								SHA:  github.String("1235"),
+								Ref:  github.String("feature"),
+								Repo: repository,
 							},
 						}
 
@@ -340,31 +345,19 @@ var _ = Describe("github-review-helper", func() {
 						})
 
 						Context("with the PR being mergeable", func() {
-							headRef := "feature"
+							headSHA := "1235"
 							pr := &github.PullRequest{
 								Merged:    github.Bool(false),
 								Mergeable: github.Bool(true),
 								Base: &github.PullRequestBranch{
-									SHA: github.String("1234"),
-									Ref: github.String("master"),
-									Repo: &github.Repository{
-										Owner: &github.User{
-											Login: github.String(repositoryOwner),
-										},
-										Name:   github.String(repositoryName),
-										SSHURL: github.String(sshURL),
-									},
+									SHA:  github.String("1234"),
+									Ref:  github.String("master"),
+									Repo: repository,
 								},
 								Head: &github.PullRequestBranch{
-									SHA: github.String("1235"),
-									Ref: github.String(headRef),
-									Repo: &github.Repository{
-										Owner: &github.User{
-											Login: github.String(repositoryOwner),
-										},
-										Name:   github.String(repositoryName),
-										SSHURL: github.String(sshURL),
-									},
+									SHA:  github.String(headSHA),
+									Ref:  github.String("feature"),
+									Repo: repository,
 								},
 							}
 
@@ -375,7 +368,7 @@ var _ = Describe("github-review-helper", func() {
 							Context("with combined state being failing", func() {
 								BeforeEach(func() {
 									repositories.
-										On("GetCombinedStatus", repositoryOwner, repositoryName, headRef, mock.AnythingOfType("*github.ListOptions")).
+										On("GetCombinedStatus", repositoryOwner, repositoryName, headSHA, mock.AnythingOfType("*github.ListOptions")).
 										Return(&github.CombinedStatus{
 											State: github.String("failing"),
 										}, &github.Response{}, nil)
@@ -390,7 +383,7 @@ var _ = Describe("github-review-helper", func() {
 							Context("with a pending squash status in paged combined status request", func() {
 								BeforeEach(func() {
 									repositories.
-										On("GetCombinedStatus", repositoryOwner, repositoryName, headRef, &github.ListOptions{
+										On("GetCombinedStatus", repositoryOwner, repositoryName, headSHA, &github.ListOptions{
 											Page:    1,
 											PerPage: 100,
 										}).
@@ -406,7 +399,7 @@ var _ = Describe("github-review-helper", func() {
 											NextPage: 2,
 										}, nil)
 									repositories.
-										On("GetCombinedStatus", repositoryOwner, repositoryName, headRef, &github.ListOptions{
+										On("GetCombinedStatus", repositoryOwner, repositoryName, headSHA, &github.ListOptions{
 											Page:    2,
 											PerPage: 100,
 										}).
@@ -427,7 +420,7 @@ var _ = Describe("github-review-helper", func() {
 							Context("with combined state being success", func() {
 								BeforeEach(func() {
 									repositories.
-										On("GetCombinedStatus", repositoryOwner, repositoryName, headRef, mock.AnythingOfType("*github.ListOptions")).
+										On("GetCombinedStatus", repositoryOwner, repositoryName, headSHA, mock.AnythingOfType("*github.ListOptions")).
 										Return(&github.CombinedStatus{
 											State: github.String("success"),
 										}, &github.Response{}, nil)
@@ -569,7 +562,8 @@ var _ = Describe("github-review-helper", func() {
 							BeforeEach(func() {
 								pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(&github.PullRequest{
 									Head: &github.PullRequestBranch{
-										SHA: github.String(commitRevision),
+										SHA:  github.String(commitRevision),
+										Repo: repository,
 									},
 								}, nil, nil)
 							})
@@ -683,7 +677,8 @@ var _ = Describe("github-review-helper", func() {
 								On("Get", repositoryOwner, repositoryName, issueNumber).
 								Return(&github.PullRequest{
 									Head: &github.PullRequestBranch{
-										SHA: github.String(commitRevision),
+										SHA:  github.String(commitRevision),
+										Repo: repository,
 									},
 								}, nil, nil)
 						})
@@ -732,7 +727,8 @@ var _ = Describe("github-review-helper", func() {
 								On("Get", repositoryOwner, repositoryName, issueNumber).
 								Return(&github.PullRequest{
 									Head: &github.PullRequestBranch{
-										SHA: github.String(commitRevision),
+										SHA:  github.String(commitRevision),
+										Repo: repository,
 									},
 								}, nil, nil)
 						})

--- a/main_test.go
+++ b/main_test.go
@@ -54,6 +54,13 @@ var _ = Describe("github-review-helper", func() {
 			responseRecorder = httptest.NewRecorder()
 		})
 
+		AfterEach(func() {
+			git.AssertExpectations(GinkgoT())
+			pullRequests.AssertExpectations(GinkgoT())
+			repositories.AssertExpectations(GinkgoT())
+			issues.AssertExpectations(GinkgoT())
+		})
+
 		JustBeforeEach(func() {
 			handler := CreateHandler(conf, git, pullRequests, repositories, issues)
 
@@ -216,6 +223,10 @@ var _ = Describe("github-review-helper", func() {
 							git.On("GetUpdatedRepo", sshURL, repositoryOwner, repositoryName).Return(repo, nil)
 						})
 
+						AfterEach(func() {
+							repo.AssertExpectations(GinkgoT())
+						})
+
 						Context("with autosquash failing", func() {
 							BeforeEach(func() {
 								repo.On("RebaseAutosquash", baseRef, headSHA).Return(errors.New("merge conflict"))
@@ -242,8 +253,6 @@ var _ = Describe("github-review-helper", func() {
 								repo.On("ForcePushHeadTo", headRef).Return(nil)
 
 								handle()
-
-								repo.AssertExpectations(GinkgoT())
 							})
 						})
 					})
@@ -293,14 +302,14 @@ var _ = Describe("github-review-helper", func() {
 								pullRequests.On("Get", repositoryOwner, repositoryName, issueNumber).Return(&github.PullRequest{
 									Merged: github.Bool(true),
 								}, nil, nil)
-								issues.
-									On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
-									Return(nil, nil, nil)
 							})
 
 							It("removes the 'merging' label from the PR", func() {
+								issues.
+									On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
+									Return(nil, nil, nil)
+
 								handle()
-								issues.AssertExpectations(GinkgoT())
 								Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 							})
 						})
@@ -382,16 +391,16 @@ var _ = Describe("github-review-helper", func() {
 												Merged: github.Bool(true),
 											}, nil, nil).
 											Once()
-										issues.
-											On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
-											Return(nil, nil, nil)
 									})
 
 									It("removes the 'merging' label from the PR after the merge", func() {
+										issues.
+											On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
+											Return(nil, nil, nil)
+
 										handle()
 										pullRequests.AssertNumberOfCalls(GinkgoT(), "Get", 2)
 										pullRequests.AssertNumberOfCalls(GinkgoT(), "Merge", 2)
-										issues.AssertExpectations(GinkgoT())
 										Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 									})
 								})
@@ -429,14 +438,14 @@ var _ = Describe("github-review-helper", func() {
 											Merged: github.Bool(true),
 										}, nil, nil).
 										Once()
-									issues.
-										On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
-										Return(nil, nil, nil)
 								})
 
 								It("removes the 'merging' label from the PR after the merge", func() {
+									issues.
+										On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, MergingLabel).
+										Return(nil, nil, nil)
+
 									handle()
-									issues.AssertExpectations(GinkgoT())
 									Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 								})
 							})

--- a/merge_command.go
+++ b/merge_command.go
@@ -1,0 +1,11 @@
+package main
+
+import "strings"
+
+func isMergeCommand(comment string) bool {
+	return strings.TrimSpace(comment) == "!merge"
+}
+
+func handleMergeCommand(issueComment IssueComment) Response {
+	return SuccessResponse{}
+}

--- a/merge_command.go
+++ b/merge_command.go
@@ -9,7 +9,10 @@ import (
 	"github.com/google/go-github/github"
 )
 
-const MergingLabel = "merging"
+const (
+	MergingLabel    = "merging"
+	MergeRetryLimit = 3
+)
 
 func isMergeCommand(comment string) bool {
 	return strings.TrimSpace(comment) == "!merge"
@@ -21,7 +24,7 @@ func handleMergeCommand(issueComment IssueComment, issues Issues, pullRequests P
 	if errResp != nil {
 		return errResp
 	}
-	return mergeWithRetry(3, issueComment, issues, pullRequests, repositories, git)
+	return mergeWithRetry(MergeRetryLimit, issueComment, issues, pullRequests, repositories, git)
 }
 
 func mergeWithRetry(nrOfRetries int, issueComment IssueComment, issues Issues, pullRequests PullRequests,

--- a/merge_command.go
+++ b/merge_command.go
@@ -39,7 +39,7 @@ func mergeWithRetry(nrOfRetries int, issueComment IssueComment, issues Issues, p
 	} else if !*pr.Mergeable {
 		return SuccessResponse{}
 	}
-	state, statuses, errResp := getStatuses(issueComment.Repository, *pr.Head.Ref, repositories)
+	state, statuses, errResp := getStatuses(pr, repositories)
 	if errResp != nil {
 		return errResp
 	} else if state == "pending" && containsPendingSquashStatus(statuses) {

--- a/merge_command.go
+++ b/merge_command.go
@@ -1,6 +1,10 @@
 package main
 
-import "strings"
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
 
 const mergingLabel = "merging"
 
@@ -8,10 +12,23 @@ func isMergeCommand(comment string) bool {
 	return strings.TrimSpace(comment) == "!merge"
 }
 
-func handleMergeCommand(issueComment IssueComment, issues Issues) Response {
-	err := addLabel(issueComment.Repository, issueComment.IssueNumber, mergingLabel, issues)
+func handleMergeCommand(issueComment IssueComment, issues Issues, pullRequests PullRequests) Response {
+	errResp := addLabel(issueComment.Repository, issueComment.IssueNumber, mergingLabel, issues)
+	if errResp != nil {
+		return errResp
+	}
+	pr, errResp := getPR(issueComment, pullRequests)
+	if errResp != nil {
+		return errResp
+	} else if *pr.Merged {
+		return SuccessResponse{}
+	} else if !*pr.Mergeable {
+		return SuccessResponse{}
+	}
+	err := merge(issueComment.Repository, issueComment.IssueNumber, pullRequests)
 	if err != nil {
-		return err
+		message := fmt.Sprintf("Failed to merge PR #%d", issueComment.IssueNumber)
+		return ErrorResponse{err, http.StatusBadGateway, message}
 	}
 	return SuccessResponse{}
 }

--- a/merge_command.go
+++ b/merge_command.go
@@ -2,10 +2,16 @@ package main
 
 import "strings"
 
+const mergingLabel = "merging"
+
 func isMergeCommand(comment string) bool {
 	return strings.TrimSpace(comment) == "!merge"
 }
 
-func handleMergeCommand(issueComment IssueComment) Response {
+func handleMergeCommand(issueComment IssueComment, issues Issues) Response {
+	err := addLabel(issueComment.Repository, issueComment.IssueNumber, mergingLabel, issues)
+	if err != nil {
+		return err
+	}
 	return SuccessResponse{}
 }

--- a/merge_command.go
+++ b/merge_command.go
@@ -2,39 +2,50 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 )
 
-const mergingLabel = "merging"
+const MergingLabel = "merging"
 
 func isMergeCommand(comment string) bool {
 	return strings.TrimSpace(comment) == "!merge"
 }
 
 func handleMergeCommand(issueComment IssueComment, issues Issues, pullRequests PullRequests) Response {
-	errResp := addLabel(issueComment.Repository, issueComment.IssueNumber, mergingLabel, issues)
+	errResp := addLabel(issueComment.Repository, issueComment.IssueNumber, MergingLabel, issues)
 	if errResp != nil {
 		return errResp
 	}
-	return mergeWithRetry(3, issueComment, pullRequests)
+	return mergeWithRetry(3, issueComment, issues, pullRequests)
 }
 
-func mergeWithRetry(nrOfRetries int, issueComment IssueComment, pullRequests PullRequests) Response {
+func mergeWithRetry(nrOfRetries int, issueComment IssueComment, issues Issues, pullRequests PullRequests) Response {
 	pr, errResp := getPR(issueComment, pullRequests)
 	if errResp != nil {
 		return errResp
 	} else if *pr.Merged {
+		log.Printf("PR #%d already merged. Removing the '%s' label.\n", issueComment.IssueNumber, MergingLabel)
+		errResp = removeLabel(issueComment.Repository, issueComment.IssueNumber, MergingLabel, issues)
+		if errResp != nil {
+			return errResp
+		}
 		return SuccessResponse{}
 	} else if !*pr.Mergeable {
 		return SuccessResponse{}
 	}
 	err := merge(issueComment.Repository, issueComment.IssueNumber, pullRequests)
 	if err == OutdatedMergeRefError && nrOfRetries > 0 {
-		return mergeWithRetry(nrOfRetries-1, issueComment, pullRequests)
+		return mergeWithRetry(nrOfRetries-1, issueComment, issues, pullRequests)
 	} else if err != nil {
 		message := fmt.Sprintf("Failed to merge PR #%d", issueComment.IssueNumber)
 		return ErrorResponse{err, http.StatusBadGateway, message}
+	}
+	log.Printf("PR #%d successfully merged. Removing the '%s' label.\n", issueComment.IssueNumber, MergingLabel)
+	errResp = removeLabel(issueComment.Repository, issueComment.IssueNumber, MergingLabel, issues)
+	if errResp != nil {
+		return errResp
 	}
 	return SuccessResponse{}
 }

--- a/mock_Issues.go
+++ b/mock_Issues.go
@@ -1,0 +1,40 @@
+package main
+
+import "github.com/stretchr/testify/mock"
+
+import "github.com/google/go-github/github"
+
+type MockIssues struct {
+	mock.Mock
+}
+
+func (_m *MockIssues) AddLabelsToIssue(owner string, repo string, number int, labels []string) ([]github.Label, *github.Response, error) {
+	ret := _m.Called(owner, repo, number, labels)
+
+	var r0 []github.Label
+	if rf, ok := ret.Get(0).(func(string, string, int, []string) []github.Label); ok {
+		r0 = rf(owner, repo, number, labels)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]github.Label)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, string, int, []string) *github.Response); ok {
+		r1 = rf(owner, repo, number, labels)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, int, []string) error); ok {
+		r2 = rf(owner, repo, number, labels)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}

--- a/mock_Issues.go
+++ b/mock_Issues.go
@@ -38,3 +38,24 @@ func (_m *MockIssues) AddLabelsToIssue(owner string, repo string, number int, la
 
 	return r0, r1, r2
 }
+func (_m *MockIssues) RemoveLabelForIssue(owner string, repo string, number int, label string) (*github.Response, error) {
+	ret := _m.Called(owner, repo, number, label)
+
+	var r0 *github.Response
+	if rf, ok := ret.Get(0).(func(string, string, int, string) *github.Response); ok {
+		r0 = rf(owner, repo, number, label)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.Response)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, int, string) error); ok {
+		r1 = rf(owner, repo, number, label)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/mock_PullRequests.go
+++ b/mock_PullRequests.go
@@ -68,3 +68,33 @@ func (_m *MockPullRequests) ListCommits(owner string, repo string, number int, o
 
 	return r0, r1, r2
 }
+func (_m *MockPullRequests) Merge(owner string, repo string, number int, commitMessage string) (*github.PullRequestMergeResult, *github.Response, error) {
+	ret := _m.Called(owner, repo, number, commitMessage)
+
+	var r0 *github.PullRequestMergeResult
+	if rf, ok := ret.Get(0).(func(string, string, int, string) *github.PullRequestMergeResult); ok {
+		r0 = rf(owner, repo, number, commitMessage)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.PullRequestMergeResult)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, string, int, string) *github.Response); ok {
+		r1 = rf(owner, repo, number, commitMessage)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, int, string) error); ok {
+		r2 = rf(owner, repo, number, commitMessage)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}

--- a/mock_Repositories.go
+++ b/mock_Repositories.go
@@ -38,3 +38,33 @@ func (_m *MockRepositories) CreateStatus(owner string, repo string, ref string, 
 
 	return r0, r1, r2
 }
+func (_m *MockRepositories) GetCombinedStatus(owner string, repo string, ref string, opt *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+	ret := _m.Called(owner, repo, ref, opt)
+
+	var r0 *github.CombinedStatus
+	if rf, ok := ret.Get(0).(func(string, string, string, *github.ListOptions) *github.CombinedStatus); ok {
+		r0 = rf(owner, repo, ref, opt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.CombinedStatus)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, string, string, *github.ListOptions) *github.Response); ok {
+		r1 = rf(owner, repo, ref, opt)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, string, *github.ListOptions) error); ok {
+		r2 = rf(owner, repo, ref, opt)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}

--- a/model.go
+++ b/model.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/google/go-github/github"
+)
 
 type (
 	Issue struct {
@@ -48,4 +51,12 @@ func (p PullRequestEvent) Issue() Issue {
 
 func (i Issue) FullName() string {
 	return fmt.Sprintf("%s/%s#%d", i.Repository.Owner, i.Repository.Name, i.Number)
+}
+
+func internalRepositoryRepresentation(githubRepository *github.Repository) Repository {
+	return Repository{
+		Owner: *githubRepository.Owner.Login,
+		Name:  *githubRepository.Name,
+		URL:   *githubRepository.SSHURL,
+	}
 }

--- a/squash.go
+++ b/squash.go
@@ -66,13 +66,7 @@ func squashAndReportFailure(pr *github.PullRequest, git Git, repositories Reposi
 	if err == RebaseError {
 		log.Printf("Failed to autosquash the commits with an interactive rebase: %s. Setting a failure status.\n", err)
 		status := createSquashStatus("failure", "Automatic squash failed. Please squash manually")
-		// I'm assuming (because the documentation on this is unclear) that the
-		// status has to be reported for the Head repository. It might seem
-		// weird, because why should a bot configured for the Base repository
-		// have access to the Head repository, but AFAIK all forks must be
-		// public and reporting statuses on public repos is always allowed.
-		headRepository := internalRepositoryRepresentation(pr.Head.Repo)
-		if errResp := setStatus(headRepository, *pr.Head.SHA, status, repositories); errResp != nil {
+		if errResp := setStatus(pr, status, repositories); errResp != nil {
 			return errResp
 		}
 		return SuccessResponse{}

--- a/squash.go
+++ b/squash.go
@@ -78,7 +78,7 @@ func squash(pr *github.PullRequest, git Git, repositories Repositories) error {
 	if err != nil {
 		return errors.New("Failed to update the local repo")
 	}
-	if err = repo.RebaseAutosquash(*pr.Base.SHA, *pr.Head.SHA); err != nil {
+	if err = repo.RebaseAutosquash(*pr.Base.Ref, *pr.Head.SHA); err != nil {
 		return RebaseError
 	}
 	if err = repo.ForcePushHeadTo(*pr.Head.Ref); err != nil {

--- a/squash.go
+++ b/squash.go
@@ -37,9 +37,6 @@ func handleSquashCommand(issueComment IssueComment, git Git, pullRequests PullRe
 }
 
 func checkForFixupCommits(pullRequestEvent PullRequestEvent, pullRequests PullRequests, repositories Repositories) Response {
-	if !(pullRequestEvent.Action == "opened" || pullRequestEvent.Action == "synchronize") {
-		return SuccessResponse{"PR not opened or synchronized. Ignoring."}
-	}
 	log.Printf("Checking for fixup commits for PR %s.\n", pullRequestEvent.Issue().FullName())
 	commits, errResp := getCommits(pullRequestEvent, pullRequests)
 	if errResp != nil {

--- a/squash.go
+++ b/squash.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"strings"
 
 	"github.com/google/go-github/github"
 )
+
+var RebaseError = errors.New("Rebase failed")
 
 func isSquashCommand(comment string) bool {
 	return strings.TrimSpace(comment) == "!squash"
@@ -18,20 +21,16 @@ func handleSquashCommand(issueComment IssueComment, git Git, pullRequests PullRe
 		return errResp
 	}
 	log.Printf("Squashing %s that's going to be merged into %s\n", *pr.Head.Ref, *pr.Base.Ref)
-	repo, err := git.GetUpdatedRepo(issueComment.Repository.URL, issueComment.Repository.Owner, issueComment.Repository.Name)
-	if err != nil {
-		return ErrorResponse{err, http.StatusInternalServerError, "Failed to update the local repo"}
-	}
-	if err = repo.RebaseAutosquash(*pr.Base.SHA, *pr.Head.SHA); err != nil {
+	err := squash(pr, git, repositories)
+	if err == RebaseError {
 		log.Printf("Failed to autosquash the commits with an interactive rebase: %s. Setting a failure status.\n", err)
 		status := createSquashStatus("failure", "Automatic squash failed. Please squash manually")
 		if errResp := setStatus(issueComment.Repository, *pr.Head.SHA, status, repositories); errResp != nil {
 			return errResp
 		}
-		return SuccessResponse{"Failed to autosquash the commits with an interactive rebase. Reported the failure."}
-	}
-	if err = repo.ForcePushHeadTo(*pr.Head.Ref); err != nil {
-		return ErrorResponse{err, http.StatusInternalServerError, "Failed to push the squashed version"}
+		return SuccessResponse{}
+	} else if err != nil {
+		return ErrorResponse{err, http.StatusInternalServerError, "Failed to squash the commits in the PR"}
 	}
 	return SuccessResponse{}
 }
@@ -71,4 +70,19 @@ func createSquashStatus(state, description string) *github.RepoStatus {
 		Description: github.String(description),
 		Context:     github.String(githubStatusSquashContext),
 	}
+}
+
+func squash(pr *github.PullRequest, git Git, repositories Repositories) error {
+	headRepository := internalRepositoryRepresentation(pr.Head.Repo)
+	repo, err := git.GetUpdatedRepo(headRepository.URL, headRepository.Owner, headRepository.Name)
+	if err != nil {
+		return errors.New("Failed to update the local repo")
+	}
+	if err = repo.RebaseAutosquash(*pr.Base.SHA, *pr.Head.SHA); err != nil {
+		return RebaseError
+	}
+	if err = repo.ForcePushHeadTo(*pr.Head.Ref); err != nil {
+		return errors.New("Failed to push the squashed version")
+	}
+	return nil
 }


### PR DESCRIPTION
These changes introduce a `!merge` command that currently does the following:
- Sets the `merging` label for the PR;
- Merges the PR if it's mergeable and doesn't have any failed/pending statuses;
- If there are any fixup commits (identified by a pending `review/squash` status) it behaves exactly as a `!squash` command would.

This is just the ground work for the `!merge` command and means that isn't currently usable in any meaningful way. At least the following steps are necessary and still to be done for the command to be actually useful, but they will be tackled in separate PRs:
- Listen to status change events and PR `synchronized` events and find any related PRs with the `merging` label. See if the found PRs (updated, and having the `merging` label) are ready to be merged and merge if they are;
- Restore `review/peer` statuses after squashing.

I suggest reviewing commit by commit. I won't do any large refactorings as a part of this PR, but feel free to suggest ideas for future improvements.