### PR TITLE
Quickfix rebasing onto old revisions

### DIFF
--- a/squash.go
+++ b/squash.go
@@ -83,7 +83,7 @@ func squash(pr *github.PullRequest, gitRepos git.Repos, repositories Repositorie
 	if err != nil {
 		return errors.New("Failed to update the local repo")
 	}
-	if err = gitRepo.RebaseAutosquash(*pr.Base.Ref, *pr.Head.SHA); err != nil {
+	if err = gitRepo.RebaseAutosquash("origin/"+*pr.Base.Ref, *pr.Head.SHA); err != nil {
 		return ErrRebase
 	}
 	if err = gitRepo.ForcePushHeadTo(*pr.Head.Ref); err != nil {

--- a/squash_command_test.go
+++ b/squash_command_test.go
@@ -107,7 +107,7 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 	Context("with autosquash failing", func() {
 		BeforeEach(func() {
 			gitRepo.
-				On("RebaseAutosquash", baseRef, headSHA).
+				On("RebaseAutosquash", "origin/"+baseRef, headSHA).
 				Return(errors.New("merge conflict"))
 		})
 
@@ -127,7 +127,7 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 	Context("with autosquash succeeding", func() {
 		BeforeEach(func() {
 			gitRepo.
-				On("RebaseAutosquash", baseRef, headSHA).
+				On("RebaseAutosquash", "origin/"+baseRef, headSHA).
 				Return(nil)
 		})
 


### PR DESCRIPTION
There's an issue where the local repository used by the bot and more
specifically it's local branches that are tracking remote (origin)
branches become out of date. I.e. when updating the repository, we
currently only do a fetch, which means that if origin/master moves, we
don't move the local master with it. Which in turn means that if we do a
rebase against master than we're rebasing against that outdated ref.

This is a quickfix around the issue, that works by only using the remote
refs. A proper solution has to correctly handle all remotes (forks etc).
Although, even with forks, the base remote will always still be origin.