### PR TITLE
Add logging for when updating PR status

### DIFF
--- a/github.go
+++ b/github.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/google/go-github/github"
@@ -32,6 +33,13 @@ func setPRHeadStatus(issueable Issueable, status *github.RepoStatus, pullRequest
 	if errResp != nil {
 		return errResp
 	}
+	log.Printf(
+		"Setting %s status to %s for PR %s (revision %s).\n",
+		*status.Context,
+		*status.State,
+		issueable.Issue().FullName(),
+		*pr.Head.SHA,
+	)
 	return setStatus(pr, status, repositories)
 }
 


### PR DESCRIPTION
Sometimes the logs show that the PR is checked for fixup commits, but
the squash status is wrong. Add logging to try to find out what's going
wrong.