### PR TITLE
Try continuing a merge after status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## What?
 **github-review-helper** is a little bot that you can set up GitHub hooks for to improve your project's PR review flow.
-It currently does 3 things:
+It currently does 4 things:
 
 1. It observes all PRs and detects if any `fixup!` or `squash!` commits are
    included in the PR. If there are, it uses the GitHub status API to mark the
@@ -29,6 +29,11 @@ It currently does 3 things:
    because the bot is fast and can at times fetch data from the GitHub API
    before that data has been updated, causing the bot to make it's judgment
    based on outdated data.
+4. It listens for `!merge` commands. `!merge` command will squash the PR
+   (exactly like `!squash` would) if needed and will then merge the PR as soon
+   as all required status checks are marked as "success". If any of the status
+   checks fail after that, the bot will cancel the merging process (indicated
+   by a 'merging' label on the PR) and will notify the PR's author.
 
 ## Quick start
 ### Create an access token for the bot
@@ -101,8 +106,8 @@ services**. After that, click on **Add webhook**. Then:
  - Enter the ngrok address you marked down earlier as the **Payload URL**
  - Leave **Content type** to be `application/json`
  - Enter the secret token you created before and used to start the bot as the **Secret**
- - Use the **Let me set individual events** option and select the **Issue comment** and **Pull Request** events from the
-   list that gets opened
+ - Use the **Let me set individual events** option and select the **Issue comment**, **Pull Request**, and **Status**
+   events from the list that gets opened
  - Enable the webhook by leaving the **Active** checkbox checked
 
 Click on **Add webhook** to finish the process.

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -96,7 +96,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				Context("with an arbitrary comment", func() {
 					requestJSON.Is(func() string {
-						return IssueCommentEvent("just a simple comment")
+						return IssueCommentEvent("just a simple comment", arbitraryIssueAuthor)
 					})
 
 					It("succeeds with 'ignored' response", func() {

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -52,9 +52,10 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 		Context("with GitHub request to list commits failing", func() {
 			Context("with a 404", func() {
 				BeforeEach(func() {
+					resp, err := createGithubErrorResponse(http.StatusNotFound)
 					pullRequests.
 						On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
-						Return(nil, nil, createGithubErrorResponse(404))
+						Return(nil, resp, err)
 				})
 
 				It("fails with a gateway error", func() {

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -46,7 +46,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			}
 		})
 		requestJSON.Is(func() string {
-			return IssueCommentEvent("!check")
+			return IssueCommentEvent("!check", arbitraryIssueAuthor)
 		})
 
 		Context("with GitHub request to list commits failing", func() {

--- a/github.go
+++ b/github.go
@@ -125,7 +125,7 @@ func getCommits(issueable Issueable, pullRequests PullRequests) ([]*github.Repos
 		}
 		pageCommits, resp, err := pullRequests.ListCommits(issue.Repository.Owner, issue.Repository.Name, issue.Number, listOptions)
 		if err != nil {
-			if is404Error(err) && nrOfRetriesLeft > 0 {
+			if is404Error(resp) && nrOfRetriesLeft > 0 {
 				log.Printf("Getting commits for PR %s failed with a 404: \"%s\". Trying again.\n", issue.FullName(), err.Error())
 				nrOfRetriesLeft = nrOfRetriesLeft - 1
 				continue
@@ -177,10 +177,6 @@ func merge(repository Repository, issueNumber int, pullRequests PullRequests) er
 	return nil
 }
 
-func is404Error(err error) bool {
-	if errResp, ok := err.(*github.ErrorResponse); ok {
-		return errResp.Response.StatusCode == 404
-	}
-	log.Println("Unable to cast the error to the expected type")
-	return false
+func is404Error(resp *github.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusNotFound
 }

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -38,6 +38,9 @@ var (
 		Name:   github.String(repositoryName),
 		SSHURL: github.String(sshURL),
 	}
+	emptyResult   = (interface{})(nil)
+	emptyResponse = &github.Response{Response: &http.Response{}}
+	noError       = (error)(nil)
 )
 
 func TestGithubReviewHelper(t *testing.T) {

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/github"
 	grh "github.com/salemove/github-review-helper"
@@ -178,6 +179,36 @@ var PullRequestEvent = func(action, headSHA string, headRepository grh.Repositor
       }
     }
   },
+  "repository": {
+    "name": "` + repositoryName + `",
+    "owner": {
+      "login": "` + repositoryOwner + `"
+    },
+    "ssh_url": "` + sshURL + `"
+  }
+}`
+}
+
+var createStatusEvent = func(sha, state string, branches []grh.Branch) string {
+	branchSHAs := make([]string, len(branches))
+	for i, branch := range branches {
+		branchSHAs[i] = branch.SHA
+	}
+	return `{
+  "sha": "` + sha + `",
+  "state": "` + state + `",
+  "branches": [
+    {
+      "commit": {
+        "sha": "` + strings.Join(branchSHAs, `"
+      }
+    },
+    {
+      "commit": {
+        "sha": "`) + `"
+      }
+    }
+  ],
   "repository": {
     "name": "` + repositoryName + `",
     "owner": {

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -55,6 +55,7 @@ type WebhookTestContext struct {
 	PullRequests     **mocks.PullRequests
 	Repositories     **mocks.Repositories
 	Issues           **mocks.Issues
+	Search           **mocks.Search
 }
 
 type WebhookTest func(WebhookTestContext)
@@ -78,6 +79,7 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 			pullRequests     = new(*mocks.PullRequests)
 			repositories     = new(*mocks.Repositories)
 			issues           = new(*mocks.Issues)
+			search           = new(*mocks.Search)
 		)
 
 		BeforeEach(func() {
@@ -85,13 +87,14 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 			*pullRequests = new(mocks.PullRequests)
 			*repositories = new(mocks.Repositories)
 			*issues = new(mocks.Issues)
+			*search = new(mocks.Search)
 
 			*responseRecorder = httptest.NewRecorder()
 
 			conf = grh.Config{
 				Secret: "a-secret",
 			}
-			*handler = grh.CreateHandler(conf, *gitRepos, *pullRequests, *repositories, *issues)
+			*handler = grh.CreateHandler(conf, *gitRepos, *pullRequests, *repositories, *issues, *search)
 		})
 
 		JustBeforeEach(func() {
@@ -118,6 +121,7 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 			(*pullRequests).AssertExpectations(GinkgoT())
 			(*repositories).AssertExpectations(GinkgoT())
 			(*issues).AssertExpectations(GinkgoT())
+			(*search).AssertExpectations(GinkgoT())
 		})
 
 		var handle = func() {
@@ -134,6 +138,7 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 			PullRequests:     pullRequests,
 			Repositories:     repositories,
 			Issues:           issues,
+			Search:           search,
 		})
 	})
 

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	repositoryOwner = "salemove"
-	repositoryName  = "github-review-helper"
-	sshURL          = "git@github.com:salemove/github-review-helper.git"
-	issueNumber     = 7
+	repositoryOwner      = "salemove"
+	repositoryName       = "github-review-helper"
+	sshURL               = "git@github.com:salemove/github-review-helper.git"
+	issueNumber          = 7
+	arbitraryIssueAuthor = "author"
 )
 
 var (
@@ -141,12 +142,15 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 	return true
 }
 
-var IssueCommentEvent = func(comment string) string {
+var IssueCommentEvent = func(comment, issueAuthor string) string {
 	return `{
   "issue": {
     "number": ` + strconv.Itoa(issueNumber) + `,
     "pull_request": {
       "url": "https://api.github.com/repos/` + repositoryOwner + `/` + repositoryName + `/pulls/` + strconv.Itoa(issueNumber) + `"
+    },
+    "user": {
+      "login": "` + issueAuthor + `"
     }
   },
   "comment": {
@@ -177,6 +181,9 @@ var PullRequestEvent = func(action, headSHA string, headRepository grh.Repositor
         },
         "ssh_url": "` + headRepository.URL + `"
       }
+    },
+    "user": {
+      "login": "` + arbitraryIssueAuthor + `"
     }
   },
   "repository": {

--- a/handler.go
+++ b/handler.go
@@ -36,5 +36,6 @@ type SuccessResponse struct {
 }
 
 func (r SuccessResponse) WriteResponse(w http.ResponseWriter) {
+	log.Printf("Responding with a success message: %s\n", r.Message)
 	w.Write([]byte(r.Message))
 }

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -1,0 +1,93 @@
+package main_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	grh "github.com/salemove/github-review-helper"
+	"github.com/salemove/github-review-helper/mocks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = TestWebhookHandler(func(context WebhookTestContext) {
+	mockSHA := "c9b5e1096a18765a14f6fb295c585efd40487a24"
+
+	Describe("status update", func() {
+		var (
+			handle      = context.Handle
+			headers     = context.Headers
+			requestJSON = context.RequestJSON
+
+			responseRecorder *httptest.ResponseRecorder
+			pullRequests     *mocks.PullRequests
+			repositories     *mocks.Repositories
+			issues           *mocks.Issues
+		)
+		BeforeEach(func() {
+			responseRecorder = *context.ResponseRecorder
+			pullRequests = *context.PullRequests
+			repositories = *context.Repositories
+			issues = *context.Issues
+		})
+
+		headers.Is(func() map[string]string {
+			return map[string]string{
+				"X-Github-Event": "status",
+			}
+		})
+
+		for _, badStatus := range []string{"pending", "failure", "error"} {
+			Context("with "+badStatus+" status", func() {
+				branches := []grh.Branch{grh.Branch{
+					SHA: mockSHA,
+				}}
+
+				requestJSON.Is(func() string {
+					return createStatusEvent(mockSHA, badStatus, branches)
+				})
+
+				It("fails with internal error", func() {
+					handle()
+					Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
+				})
+			})
+		}
+
+		Context("with success status", func() {
+			status := "success"
+
+			Context("when updating a commit that is not a branch's head", func() {
+				otherSHA := "4eaf26faa8819ab5aee991461b8c4fff41778f41"
+				branches := []grh.Branch{grh.Branch{
+					SHA: otherSHA,
+				}}
+
+				requestJSON.Is(func() string {
+					return createStatusEvent(mockSHA, status, branches)
+				})
+
+				It("fails with internal error", func() {
+					handle()
+					Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
+				})
+			})
+
+			Context("when updating a commit that is a branch's head", func() {
+				branches := []grh.Branch{grh.Branch{
+					SHA: mockSHA,
+				}}
+
+				requestJSON.Is(func() string {
+					return createStatusEvent(mockSHA, status, branches)
+				})
+
+				It("returns 200 OK", func() {
+					handle()
+					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+				})
+			})
+		})
+	})
+})

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -1,11 +1,15 @@
 package main_test
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/google/go-github/github"
 	grh "github.com/salemove/github-review-helper"
 	"github.com/salemove/github-review-helper/mocks"
+	"github.com/stretchr/testify/mock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -22,14 +26,14 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 			responseRecorder *httptest.ResponseRecorder
 			pullRequests     *mocks.PullRequests
-			repositories     *mocks.Repositories
 			issues           *mocks.Issues
+			search           *mocks.Search
 		)
 		BeforeEach(func() {
 			responseRecorder = *context.ResponseRecorder
 			pullRequests = *context.PullRequests
-			repositories = *context.Repositories
 			issues = *context.Issues
+			search = *context.Search
 		})
 
 		headers.Is(func() map[string]string {
@@ -48,9 +52,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					return createStatusEvent(mockSHA, badStatus, branches)
 				})
 
-				It("fails with internal error", func() {
+				It("returns 200 OK", func() {
 					handle()
-					Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
+					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 				})
 			})
 		}
@@ -68,9 +72,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					return createStatusEvent(mockSHA, status, branches)
 				})
 
-				It("fails with internal error", func() {
+				It("returns 200 OK", func() {
 					handle()
-					Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
+					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 				})
 			})
 
@@ -83,9 +87,123 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					return createStatusEvent(mockSHA, status, branches)
 				})
 
-				It("returns 200 OK", func() {
-					handle()
-					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+				mockSearchQuery := func(pageNr int) *mock.Call {
+					searchQuery := fmt.Sprintf("%s label:\"%s\" is:open repo:%s/%s status:success",
+						mockSHA, grh.MergingLabel, repositoryOwner, repositoryName)
+					return search.
+						On("Issues", searchQuery, mock.MatchedBy(func(searchOptions *github.SearchOptions) bool {
+							return searchOptions.Page == pageNr
+						}))
+				}
+
+				Context("with issue search failing", func() {
+					BeforeEach(func() {
+						mockSearchQuery(1).Return(nil, nil, errors.New("arbitrary error"))
+					})
+
+					It("fails with a gateway error", func() {
+						handle()
+						Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+					})
+				})
+
+				Context("with issue search return 0 PRs", func() {
+					BeforeEach(func() {
+						searchResult := &github.IssuesSearchResult{
+							Total:  github.Int(0),
+							Issues: []github.Issue{},
+						}
+						mockSearchQuery(1).Return(searchResult, &github.Response{}, nil)
+					})
+
+					It("returns 200 OK", func() {
+						handle()
+						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+					})
+				})
+
+				Context("with issue search return a PR", func() {
+					userName := "bestcoder"
+					issueNumber := 7331
+
+					BeforeEach(func() {
+						searchResult := &github.IssuesSearchResult{
+							Total: github.Int(1),
+							Issues: []github.Issue{github.Issue{
+								Number: github.Int(issueNumber),
+								User: &github.User{
+									Login: github.String(userName),
+								},
+							}},
+						}
+						mockSearchQuery(1).Return(searchResult, &github.Response{}, nil)
+					})
+
+					ItMergesPR(context, userName, issueNumber)
+				})
+
+				Context("with issue search returning 2 PRs", func() {
+					firstIssueNumber := 561
+					secondIssueNumber := 562
+					firstAuthor := "me"
+					secondAuthor := "you"
+
+					expectMerge := func(number int) {
+						additionalCommitMessage := ""
+						pullRequests.
+							On(
+								"Merge",
+								repositoryOwner,
+								repositoryName,
+								number,
+								additionalCommitMessage,
+								noSquashOpts,
+							).
+							Return(&github.PullRequestMergeResult{
+								Merged: github.Bool(true),
+							}, nil, nil).
+							Once()
+					}
+					expectLabelRemove := func(number int) {
+						issues.
+							On("RemoveLabelForIssue", repositoryOwner, repositoryName, number, grh.MergingLabel).
+							Return(nil, nil).
+							Once()
+
+					}
+
+					BeforeEach(func() {
+						firstPageSearchResult := &github.IssuesSearchResult{
+							Total: github.Int(1),
+							Issues: []github.Issue{github.Issue{
+								Number: github.Int(firstIssueNumber),
+								User: &github.User{
+									Login: github.String(firstAuthor),
+								},
+							}},
+						}
+						secondPageSearchResult := &github.IssuesSearchResult{
+							Total: github.Int(1),
+							Issues: []github.Issue{github.Issue{
+								Number: github.Int(secondIssueNumber),
+								User: &github.User{
+									Login: github.String(secondAuthor),
+								},
+							}},
+						}
+						mockSearchQuery(1).Return(firstPageSearchResult, &github.Response{NextPage: 2}, nil)
+						mockSearchQuery(2).Return(secondPageSearchResult, &github.Response{}, nil)
+					})
+
+					It("it merges both PRs and removes the 'merging' label from both PRs after the merge", func() {
+						expectMerge(firstIssueNumber)
+						expectLabelRemove(firstIssueNumber)
+						expectMerge(secondIssueNumber)
+						expectLabelRemove(secondIssueNumber)
+
+						handle()
+						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+					})
 				})
 			})
 		})

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -98,7 +98,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				Context("with issue search failing", func() {
 					BeforeEach(func() {
-						mockSearchQuery(1).Return(nil, nil, errors.New("arbitrary error"))
+						mockSearchQuery(1).Return(emptyResult, emptyResponse, errors.New("arbitrary error"))
 					})
 
 					It("fails with a gateway error", func() {
@@ -113,7 +113,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Total:  github.Int(0),
 							Issues: []github.Issue{},
 						}
-						mockSearchQuery(1).Return(searchResult, &github.Response{}, nil)
+						mockSearchQuery(1).Return(searchResult, &github.Response{}, noError)
 					})
 
 					It("returns 200 OK", func() {
@@ -136,7 +136,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								},
 							}},
 						}
-						mockSearchQuery(1).Return(searchResult, &github.Response{}, nil)
+						mockSearchQuery(1).Return(searchResult, &github.Response{}, noError)
 					})
 
 					ItMergesPR(context, userName, issueNumber)
@@ -161,13 +161,13 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							).
 							Return(&github.PullRequestMergeResult{
 								Merged: github.Bool(true),
-							}, nil, nil).
+							}, emptyResponse, noError).
 							Once()
 					}
 					expectLabelRemove := func(number int) {
 						issues.
 							On("RemoveLabelForIssue", repositoryOwner, repositoryName, number, grh.MergingLabel).
-							Return(nil, nil).
+							Return(emptyResponse, noError).
 							Once()
 
 					}
@@ -191,8 +191,8 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								},
 							}},
 						}
-						mockSearchQuery(1).Return(firstPageSearchResult, &github.Response{NextPage: 2}, nil)
-						mockSearchQuery(2).Return(secondPageSearchResult, &github.Response{}, nil)
+						mockSearchQuery(1).Return(firstPageSearchResult, &github.Response{NextPage: 2}, noError)
+						mockSearchQuery(2).Return(secondPageSearchResult, &github.Response{}, noError)
 					})
 
 					It("it merges both PRs and removes the 'merging' label from both PRs after the merge", func() {

--- a/merge_command_test.go
+++ b/merge_command_test.go
@@ -200,14 +200,14 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							}, &github.Response{}, nil)
 					})
 
-					ItMergesPR(context, issueAuthor)
+					ItMergesPR(context, issueAuthor, issueNumber)
 				})
 			})
 		})
 	})
 })
 
-var ItMergesPR = func(context WebhookTestContext, issueAuthor string) {
+var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumber int) {
 	var (
 		handle = context.Handle
 

--- a/merge_command_test.go
+++ b/merge_command_test.go
@@ -51,7 +51,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			BeforeEach(func() {
 				issues.
 					On("AddLabelsToIssue", repositoryOwner, repositoryName, issueNumber, []string{grh.MergingLabel}).
-					Return(nil, nil, errors.New("an error"))
+					Return(emptyResult, emptyResponse, errors.New("an error"))
 			})
 
 			It("fails with a gateway error", func() {
@@ -64,14 +64,14 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			BeforeEach(func() {
 				issues.
 					On("AddLabelsToIssue", repositoryOwner, repositoryName, issueNumber, []string{grh.MergingLabel}).
-					Return(nil, nil, nil)
+					Return(emptyResult, emptyResponse, noError)
 			})
 
 			Context("with fetching the PR failing", func() {
 				BeforeEach(func() {
 					pullRequests.
 						On("Get", repositoryOwner, repositoryName, issueNumber).
-						Return(nil, nil, errors.New("an error"))
+						Return(emptyResult, emptyResponse, errors.New("an error"))
 				})
 
 				It("fails with a gateway error", func() {
@@ -86,13 +86,13 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						On("Get", repositoryOwner, repositoryName, issueNumber).
 						Return(&github.PullRequest{
 							Merged: github.Bool(true),
-						}, nil, nil)
+						}, emptyResponse, noError)
 				})
 
 				It("removes the 'merging' label from the PR", func() {
 					issues.
 						On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, grh.MergingLabel).
-						Return(nil, nil)
+						Return(emptyResponse, noError)
 
 					handle()
 					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
@@ -106,7 +106,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						Return(&github.PullRequest{
 							Merged:    github.Bool(false),
 							Mergeable: github.Bool(false),
-						}, nil, nil)
+						}, emptyResponse, noError)
 				})
 
 				It("succeeds", func() {
@@ -136,7 +136,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 				BeforeEach(func() {
 					pullRequests.
 						On("Get", repositoryOwner, repositoryName, issueNumber).
-						Return(pr, nil, nil)
+						Return(pr, emptyResponse, noError)
 				})
 
 				Context("with combined state being failing", func() {
@@ -145,7 +145,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							On("GetCombinedStatus", repositoryOwner, repositoryName, headSHA, mock.AnythingOfType("*github.ListOptions")).
 							Return(&github.CombinedStatus{
 								State: github.String("failing"),
-							}, &github.Response{}, nil)
+							}, emptyResponse, noError)
 					})
 
 					It("succeeds", func() {
@@ -171,7 +171,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								},
 							}, &github.Response{
 								NextPage: 2,
-							}, nil)
+							}, noError)
 						repositories.
 							On("GetCombinedStatus", repositoryOwner, repositoryName, headSHA, &github.ListOptions{
 								Page:    2,
@@ -185,7 +185,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 										State:   github.String("pending"),
 									},
 								},
-							}, &github.Response{}, nil)
+							}, &github.Response{}, noError)
 					})
 
 					ItSquashesPR(context, pr)
@@ -197,7 +197,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							On("GetCombinedStatus", repositoryOwner, repositoryName, headSHA, mock.AnythingOfType("*github.ListOptions")).
 							Return(&github.CombinedStatus{
 								State: github.String("success"),
-							}, &github.Response{}, nil)
+							}, emptyResponse, noError)
 					})
 
 					ItMergesPR(context, issueAuthor, issueNumber)
@@ -233,7 +233,7 @@ var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumbe
 					additionalCommitMessage,
 					noSquashOpts,
 				).
-				Return(nil, nil, errors.New("an error")).
+				Return(emptyResult, emptyResponse, errors.New("an error")).
 				Once()
 		})
 
@@ -258,7 +258,7 @@ var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumbe
 					additionalCommitMessage,
 					noSquashOpts,
 				).
-				Return(nil, &github.Response{
+				Return(emptyResult, &github.Response{
 					Response: resp,
 				}, &github.ErrorResponse{
 					Response: resp,
@@ -279,14 +279,14 @@ var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumbe
 				issues.
 					On("RemoveLabelForIssue", repositoryOwner, repositoryName,
 						issueNumber, grh.MergingLabel).
-					Return(nil, errors.New("arbitrary error"))
+					Return(emptyResponse, errors.New("arbitrary error"))
 			})
 
 			It("notifies PR author and fails with a gateway error", func() {
 				issues.
 					On("CreateComment", repositoryOwner, repositoryName,
 						issueNumber, matchIssueCommentContainingAuthorMention).
-					Return(nil, nil, nil)
+					Return(emptyResult, emptyResponse, noError)
 
 				handle()
 				Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
@@ -297,7 +297,7 @@ var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumbe
 					issues.
 						On("CreateComment", repositoryOwner, repositoryName,
 							issueNumber, matchIssueCommentContainingAuthorMention).
-						Return(nil, nil, errors.New("arbitrary error"))
+						Return(emptyResult, emptyResponse, errors.New("arbitrary error"))
 				})
 
 				It("fails with a gateway error", func() {
@@ -311,11 +311,11 @@ var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumbe
 			issues.
 				On("RemoveLabelForIssue", repositoryOwner, repositoryName,
 					issueNumber, grh.MergingLabel).
-				Return(nil, nil)
+				Return(emptyResponse, noError)
 			issues.
 				On("CreateComment", repositoryOwner, repositoryName,
 					issueNumber, matchIssueCommentContainingAuthorMention).
-				Return(nil, nil, nil)
+				Return(emptyResult, emptyResponse, noError)
 
 			handle()
 
@@ -338,7 +338,7 @@ var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumbe
 					additionalCommitMessage,
 					noSquashOpts,
 				).
-				Return(nil, &github.Response{
+				Return(emptyResult, &github.Response{
 					Response: resp,
 				}, &github.ErrorResponse{
 					Response: resp,
@@ -367,14 +367,14 @@ var ItMergesPR = func(context WebhookTestContext, issueAuthor string, issueNumbe
 				).
 				Return(&github.PullRequestMergeResult{
 					Merged: github.Bool(true),
-				}, nil, nil).
+				}, emptyResponse, noError).
 				Once()
 		})
 
 		It("removes the 'merging' label from the PR after the merge", func() {
 			issues.
 				On("RemoveLabelForIssue", repositoryOwner, repositoryName, issueNumber, grh.MergingLabel).
-				Return(nil, nil)
+				Return(emptyResponse, noError)
 
 			handle()
 			Expect(responseRecorder.Code).To(Equal(http.StatusOK))

--- a/mocks/Issues.go
+++ b/mocks/Issues.go
@@ -59,3 +59,33 @@ func (_m *Issues) RemoveLabelForIssue(owner string, repo string, number int, lab
 
 	return r0, r1
 }
+func (_m *Issues) CreateComment(owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	ret := _m.Called(owner, repo, number, comment)
+
+	var r0 *github.IssueComment
+	if rf, ok := ret.Get(0).(func(string, string, int, *github.IssueComment) *github.IssueComment); ok {
+		r0 = rf(owner, repo, number, comment)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.IssueComment)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, string, int, *github.IssueComment) *github.Response); ok {
+		r1 = rf(owner, repo, number, comment)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, int, *github.IssueComment) error); ok {
+		r2 = rf(owner, repo, number, comment)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}

--- a/mocks/Search.go
+++ b/mocks/Search.go
@@ -1,0 +1,40 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "github.com/google/go-github/github"
+
+type Search struct {
+	mock.Mock
+}
+
+func (_m *Search) Issues(query string, opt *github.SearchOptions) (*github.IssuesSearchResult, *github.Response, error) {
+	ret := _m.Called(query, opt)
+
+	var r0 *github.IssuesSearchResult
+	if rf, ok := ret.Get(0).(func(string, *github.SearchOptions) *github.IssuesSearchResult); ok {
+		r0 = rf(query, opt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.IssuesSearchResult)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, *github.SearchOptions) *github.Response); ok {
+		r1 = rf(query, opt)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, *github.SearchOptions) error); ok {
+		r2 = rf(query, opt)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}

--- a/model.go
+++ b/model.go
@@ -29,6 +29,13 @@ type (
 		Repository  Repository
 	}
 
+	StatusEvent struct {
+		SHA        string
+		State      string
+		Branches   []Branch
+		Repository Repository
+	}
+
 	Repository struct {
 		Owner string
 		Name  string
@@ -38,6 +45,10 @@ type (
 	PullRequestBranch struct {
 		SHA        string
 		Repository Repository
+	}
+
+	Branch struct {
+		SHA string // The SHA of the head commit of the branch
 	}
 )
 

--- a/model.go
+++ b/model.go
@@ -9,6 +9,7 @@ type (
 	Issue struct {
 		Number     int
 		Repository Repository
+		User User
 	}
 
 	Issueable interface {
@@ -20,6 +21,7 @@ type (
 		Comment       string
 		IsPullRequest bool
 		Repository    Repository
+		User          User
 	}
 
 	PullRequestEvent struct {
@@ -27,6 +29,7 @@ type (
 		Action      string
 		Head        PullRequestBranch
 		Repository  Repository
+		User        User
 	}
 
 	StatusEvent struct {
@@ -50,12 +53,17 @@ type (
 	Branch struct {
 		SHA string // The SHA of the head commit of the branch
 	}
+
+	User struct {
+		Login string
+	}
 )
 
 func (i IssueComment) Issue() Issue {
 	return Issue{
 		Number:     i.IssueNumber,
 		Repository: i.Repository,
+		User: i.User,
 	}
 }
 
@@ -63,6 +71,7 @@ func (p PullRequestEvent) Issue() Issue {
 	return Issue{
 		Number:     p.IssueNumber,
 		Repository: p.Repository,
+		User: p.User,
 	}
 }
 

--- a/parsers.go
+++ b/parsers.go
@@ -17,6 +17,9 @@ func parseIssueComment(body []byte) (IssueComment, error) {
 			PullRequest struct {
 				URL string `json:"url"`
 			} `json:"pull_request"`
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
 		} `json:"issue"`
 		Repository messageRepository `json:"repository"`
 		Comment    struct {
@@ -36,6 +39,9 @@ func parseIssueComment(body []byte) (IssueComment, error) {
 			Name:  message.Repository.Name,
 			URL:   message.Repository.SSHURL,
 		},
+		User: User{
+			Login: message.Issue.User.Login,
+		},
 	}, nil
 }
 
@@ -48,6 +54,9 @@ func parsePullRequestEvent(body []byte) (PullRequestEvent, error) {
 				SHA        string            `json:"sha"`
 				Repository messageRepository `json:"repo"`
 			} `json:"head"`
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
 		} `json:"pull_request"`
 		Repository messageRepository `json:"repository"`
 	}
@@ -70,6 +79,9 @@ func parsePullRequestEvent(body []byte) (PullRequestEvent, error) {
 			Owner: message.Repository.Owner.Login,
 			Name:  message.Repository.Name,
 			URL:   message.Repository.SSHURL,
+		},
+		User: User{
+			Login: message.PullRequest.User.Login,
 		},
 	}, nil
 }

--- a/pull_request_event_test.go
+++ b/pull_request_event_test.go
@@ -75,7 +75,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						resp, err := createGithubErrorResponse(http.StatusNotFound)
 						pullRequests.
 							On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
-							Return(nil, resp, err)
+							Return(emptyResult, resp, err)
 					})
 
 					It("fails with a gateway error", func() {
@@ -94,7 +94,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					BeforeEach(func() {
 						pullRequests.
 							On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
-							Return(nil, nil, errors.New("an error"))
+							Return(emptyResult, emptyResponse, errors.New("an error"))
 					})
 
 					It("fails with a gateway error", func() {
@@ -124,7 +124,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 									Message: github.String("Another casual commit"),
 								},
 							},
-						}, &github.Response{}, nil)
+						}, emptyResponse, noError)
 				})
 
 				It("reports success status to GitHub", func() {
@@ -134,7 +134,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								return *status.State == "success" && *status.Context == "review/squash"
 							}),
 						).
-						Return(nil, nil, nil)
+						Return(emptyResult, emptyResponse, noError)
 
 					handle()
 
@@ -157,7 +157,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							},
 						}, &github.Response{
 							NextPage: 2,
-						}, nil)
+						}, noError)
 					pullRequests.
 						On("ListCommits", repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
 							Page:    2,
@@ -169,7 +169,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 									Message: github.String("fixup! Changing things\n\nOopsie. Forgot a thing"),
 								},
 							},
-						}, &github.Response{}, nil)
+						}, &github.Response{}, noError)
 				})
 
 				It("reports pending squash status to GitHub", func() {
@@ -179,7 +179,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								return *status.State == "pending" && *status.Context == "review/squash"
 							}),
 						).
-						Return(nil, nil, nil)
+						Return(emptyResult, emptyResponse, noError)
 
 					handle()
 

--- a/squash_command_test.go
+++ b/squash_command_test.go
@@ -34,7 +34,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			}
 		})
 		requestJSON.Is(func() string {
-			return IssueCommentEvent("!squash")
+			return IssueCommentEvent("!squash", arbitraryIssueAuthor)
 		})
 
 		Context("with GitHub request failing", func() {

--- a/squash_command_test.go
+++ b/squash_command_test.go
@@ -41,7 +41,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			BeforeEach(func() {
 				pullRequests.
 					On("Get", repositoryOwner, repositoryName, issueNumber).
-					Return(nil, nil, errors.New("an error"))
+					Return(emptyResult, emptyResponse, errors.New("an error"))
 			})
 
 			It("fails with a gateway error", func() {
@@ -68,7 +68,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			BeforeEach(func() {
 				pullRequests.
 					On("Get", repositoryOwner, repositoryName, issueNumber).
-					Return(pr, nil, nil)
+					Return(pr, emptyResponse, noError)
 			})
 
 			ItSquashesPR(context, pr)
@@ -98,7 +98,7 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 		gitRepo = new(mocks.Repo)
 		gitRepos.
 			On("GetUpdatedRepo", sshURL, repositoryOwner, repositoryName).
-			Return(gitRepo, nil)
+			Return(gitRepo, noError)
 	})
 
 	AfterEach(func() {
@@ -117,7 +117,7 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 				On("CreateStatus", repositoryOwner, repositoryName, headSHA, mock.MatchedBy(func(status *github.RepoStatus) bool {
 					return *status.State == "failure" && *status.Context == "review/squash"
 				})).
-				Return(nil, nil, nil)
+				Return(emptyResult, emptyResponse, noError)
 
 			handle()
 
@@ -129,13 +129,13 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 		BeforeEach(func() {
 			gitRepo.
 				On("RebaseAutosquash", "origin/"+baseRef, headSHA).
-				Return(nil)
+				Return(noError)
 		})
 
 		It("pushes the squashed changes, reports status", func() {
 			gitRepo.
 				On("ForcePushHeadTo", headRef).
-				Return(nil)
+				Return(noError)
 
 			handle()
 		})


### PR DESCRIPTION
#15 added a `!merge` command, which hasn't been used, because it might get stuck. This PR adds enough hooks to PR lifecycle updates to make the command usable.