### PR TITLE
Fix squash race condition, add git tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ EXPOSE $PORT
 RUN echo "\
     UserKnownHostsFile /etc/secret-volume/known_hosts\n\
     IdentityFile /etc/secret-volume/id_rsa\n\
-" >> /etc/ssh/ssh_config && \
-  git config --global user.name 'github-review-helper' && \
-  git config --global user.email '<>'
+" >> /etc/ssh/ssh_config
 
 ADD . /go/src/github.com/salemove/github-review-helper
 RUN go get -v -d github.com/salemove/github-review-helper && \

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,0 +1,170 @@
+package git_test
+
+import (
+	"bufio"
+	"github.com/salemove/github-review-helper/git"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type file struct {
+	Name     string
+	Contents string
+}
+
+var (
+	readme = file{
+		Name:     "README.md",
+		Contents: "This is a test file\n",
+	}
+	foo = file{
+		Name:     "foo",
+		Contents: "foo\n",
+	}
+	bar = file{
+		Name:     "bar",
+		Contents: "bar\n",
+	}
+)
+
+func TestSquash(t *testing.T) {
+	skipWithoutGit(t)
+
+	testRepoDir, cleanup := createTempDir(t)
+	defer cleanup()
+	testRepoGit := gitForPath(t, testRepoDir)
+
+	testRepoGit("init")
+	createFile(t, testRepoDir, readme)
+	testRepoGit("add", readme.Name)
+	testRepoGit("commit", "-m", "Init with foo")
+
+	featureBranchName := "feature"
+	testRepoGit("checkout", "-b", featureBranchName)
+
+	createFile(t, testRepoDir, foo)
+	testRepoGit("add", foo.Name)
+	commitToFixMessage := "Add foo"
+	testRepoGit("commit", "-m", commitToFixMessage)
+
+	createFile(t, testRepoDir, bar)
+	testRepoGit("add", bar.Name)
+	testRepoGit("commit", "--fixup=@")
+
+	// Checkout master because git by default doesn't allow pushing onto
+	// branches that are currently checked out and we want to confirm that the
+	// feature branch is properly updated after the squash.
+	testRepoGit("checkout", "master")
+
+	reposDir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	gitRepos := git.NewRepos(reposDir)
+	repo, err := gitRepos.GetUpdatedRepo(testRepoDir, "my", "test-repo")
+	checkError(t, err)
+	err = repo.RebaseAutosquash("origin/master", "origin/"+featureBranchName)
+	checkError(t, err)
+	err = repo.ForcePushHeadTo(featureBranchName)
+	checkError(t, err)
+
+	// Check that all files still exist in the feature branch and that the
+	// fixup commit has been squashed to its parent
+	testRepoGit("checkout", featureBranchName)
+
+	checkFile(t, testRepoDir, readme)
+	checkFile(t, testRepoDir, foo)
+	checkFile(t, testRepoDir, bar)
+
+	headCommitMessage := testRepoGit("show", "-s", "--format=%B", "@")
+	if headCommitMessage != commitToFixMessage {
+		t.Fatalf(
+			"Expected HEAD commit to have message \"%s\", but got \"%s\"",
+			commitToFixMessage,
+			headCommitMessage,
+		)
+	}
+}
+
+func checkFile(t *testing.T, dirPath string, f file) {
+	path := filepath.Join(dirPath, f.Name)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Error(f.Name + " does not exist")
+		t.Fatal(err)
+	}
+	contents, err := ioutil.ReadFile(path)
+	checkError(t, err)
+	if string(contents) != f.Contents {
+		t.Fatal(f.Name+" has unexpected contents: ", string(contents))
+	}
+}
+
+func createFile(t *testing.T, dirPath string, f file) {
+	path := filepath.Join(dirPath, f.Name)
+	err := ioutil.WriteFile(path, []byte(f.Contents), 0644)
+	checkError(t, err)
+}
+
+func gitForPath(t *testing.T, repoPath string) func(...string) string {
+	pathArgs := []string{"-C", repoPath}
+
+	return func(args ...string) string {
+		allArgs := append(pathArgs, args...)
+		cmd := exec.Command("git", allArgs...)
+
+		stdout, err := cmd.StdoutPipe()
+		checkError(t, err)
+		stderr, err := cmd.StderrPipe()
+		checkError(t, err)
+
+		err = cmd.Start()
+		checkError(t, err)
+
+		stderrScanner := bufio.NewScanner(stderr)
+		for stderrScanner.Scan() {
+			t.Logf("stderr: %s\n", stderrScanner.Text())
+		}
+		if err := stderrScanner.Err(); err != nil {
+			t.Errorf("error reading stderr: %v\n", err)
+		}
+
+		out, err := ioutil.ReadAll(stdout)
+		checkError(t, err)
+
+		if err = cmd.Wait(); err != nil {
+			t.Fatalf(
+				"Running command \"git %s\" failed: %v\n", strings.Join(allArgs, " "),
+				err,
+			)
+		}
+		return strings.TrimSpace(string(out))
+	}
+}
+
+func skipWithoutGit(t *testing.T) {
+	_, err := exec.LookPath("git")
+	hasGit := err == nil
+	if !hasGit {
+		t.Skip("Could not find git on PATH")
+	}
+}
+
+func createTempDir(t *testing.T) (string, func()) {
+	path, err := ioutil.TempDir("", "git-test")
+	if err != nil {
+		t.Fatal("Failed to create temporary directory for the test", err)
+	}
+	cleanup := func() {
+		os.RemoveAll(path)
+	}
+	return path, cleanup
+}
+
+func checkError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -39,6 +39,9 @@ func TestSquash(t *testing.T) {
 	testRepoGit := gitForPath(t, testRepoDir)
 
 	testRepoGit("init")
+	// Configure username and email that are required for creating commits
+	testRepoGit("config", "user.name", "git-test")
+	testRepoGit("config", "user.email", "<>")
 	createFile(t, testRepoDir, readme)
 	testRepoGit("add", readme.Name)
 	testRepoGit("commit", "-m", "Init with foo")

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -66,9 +66,7 @@ func TestSquash(t *testing.T) {
 	gitRepos := git.NewRepos(reposDir)
 	repo, err := gitRepos.GetUpdatedRepo(testRepoDir, "my", "test-repo")
 	checkError(t, err)
-	err = repo.RebaseAutosquash("origin/master", "origin/"+featureBranchName)
-	checkError(t, err)
-	err = repo.ForcePushHeadTo(featureBranchName)
+	err = repo.AutosquashAndPush("origin/master", "origin/"+featureBranchName, featureBranchName)
 	checkError(t, err)
 
 	// Check that all files still exist in the feature branch and that the

--- a/mocks/Repo.go
+++ b/mocks/Repo.go
@@ -18,24 +18,12 @@ func (_m *Repo) Fetch() error {
 
 	return r0
 }
-func (_m *Repo) RebaseAutosquash(upstreamRef string, branchRef string) error {
-	ret := _m.Called(upstreamRef, branchRef)
+func (_m *Repo) AutosquashAndPush(upstreamRef string, branchRef string, destinationRef string) error {
+	ret := _m.Called(upstreamRef, branchRef, destinationRef)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = rf(upstreamRef, branchRef)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-func (_m *Repo) ForcePushHeadTo(remoteRef string) error {
-	ret := _m.Called(remoteRef)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(remoteRef)
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(upstreamRef, branchRef, destinationRef)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/squash.go
+++ b/squash.go
@@ -106,16 +106,12 @@ func squash(pr *github.PullRequest, gitRepos git.Repos, repositories Repositorie
 		log.Println(err)
 		return errors.New("Failed to update the local repo")
 	}
-	if err = gitRepo.RebaseAutosquash("origin/"+*pr.Base.Ref, *pr.Head.SHA); err != nil {
+	if err = gitRepo.AutosquashAndPush("origin/"+*pr.Base.Ref, *pr.Head.SHA, *pr.Head.Ref); err != nil {
 		log.Println(err)
 		if _, ok := err.(*git.ErrSquashConflict); ok {
 			return ErrSquashConflict
 		}
 		return err
-	}
-	if err = gitRepo.ForcePushHeadTo(*pr.Head.Ref); err != nil {
-		log.Println(err)
-		return errors.New("Failed to push the squashed version")
 	}
 	return nil
 }

--- a/squash_command_test.go
+++ b/squash_command_test.go
@@ -106,11 +106,12 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 		gitRepo.AssertExpectations(GinkgoT())
 	})
 
-	Context("with autosquash failing because of a squash conflict", func() {
+	Context("with autosquash and push failing due to a squash conflict", func() {
 		BeforeEach(func() {
+			squashErr := &git.ErrSquashConflict{errors.New("merge conflict")}
 			gitRepo.
-				On("RebaseAutosquash", "origin/"+baseRef, headSHA).
-				Return(&git.ErrSquashConflict{errors.New("merge conflict")})
+				On("AutosquashAndPush", "origin/"+baseRef, headSHA, headRef).
+				Return(squashErr)
 		})
 
 		It("reports the failure", func() {
@@ -126,10 +127,10 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 		})
 	})
 
-	Context("with autosquash failing for a different reason", func() {
+	Context("with autosquash and push failing due to a reason other than a squash conflict", func() {
 		BeforeEach(func() {
 			gitRepo.
-				On("RebaseAutosquash", "origin/"+baseRef, headSHA).
+				On("AutosquashAndPush", "origin/"+baseRef, headSHA, headRef).
 				Return(errors.New("other git error"))
 		})
 
@@ -140,18 +141,14 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 		})
 	})
 
-	Context("with autosquash succeeding", func() {
+	Context("with autosquash and push succeeding", func() {
 		BeforeEach(func() {
 			gitRepo.
-				On("RebaseAutosquash", "origin/"+baseRef, headSHA).
+				On("AutosquashAndPush", "origin/"+baseRef, headSHA, headRef).
 				Return(noError)
 		})
 
-		It("pushes the squashed changes, reports status", func() {
-			gitRepo.
-				On("ForcePushHeadTo", headRef).
-				Return(noError)
-
+		It("returns 200 OK", func() {
 			handle()
 
 			Expect(responseRecorder.Code).To(Equal(http.StatusOK))


### PR DESCRIPTION
ForcePushHeadTo, as the name says, pushed the HEAD to the specified
destination ref. This means, that for the combination of
RebaseAutosquash + ForcePushHeadTo to work correctly, nothing must
change the HEAD after RebaseAutosquash was run. Currently there's a
chance that something else will acquire the lock between the 2
functions are run, which could create considerable confusion and harm if
it were to happen.

This solution holds the lock until both commands are finished.