### PR TITLE
Allow only collaborators to send commands

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,86 @@
+package main_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/salemove/github-review-helper/mocks"
+	"github.com/stretchr/testify/mock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func ForCollaborator(context WebhookTestContext, repoOwner, repoName, user string, test func()) {
+	var (
+		handle = context.Handle
+
+		responseRecorder *httptest.ResponseRecorder
+		repositories     *mocks.Repositories
+		issues           *mocks.Issues
+	)
+	BeforeEach(func() {
+		responseRecorder = *context.ResponseRecorder
+		repositories = *context.Repositories
+		issues = *context.Issues
+	})
+
+	Context("with collaborator status check failing", func() {
+		BeforeEach(func() {
+			repositories.
+				On("IsCollaborator", repoOwner, repoName, user).
+				Return(false, emptyResponse, errArbitrary)
+		})
+
+		It("fails with a gateway error", func() {
+			handle()
+			Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+		})
+	})
+
+	Context("with user not being a collaborator", func() {
+		BeforeEach(func() {
+			repositories.
+				On("IsCollaborator", repoOwner, repoName, user).
+				Return(false, emptyResponse, noError)
+		})
+
+		Context("with sending a comment failing", func() {
+			BeforeEach(func() {
+				issues.
+					On("CreateComment", repoOwner, repoName,
+						issueNumber, mock.MatchedBy(commentMentioning(user))).
+					Return(emptyResult, emptyResponse, errArbitrary)
+			})
+
+			It("fails with a gateway error", func() {
+				handle()
+				Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+			})
+		})
+
+		Context("with sending a comment succeeding", func() {
+			BeforeEach(func() {
+				issues.
+					On("CreateComment", repoOwner, repoName,
+						issueNumber, mock.MatchedBy(commentMentioning(user))).
+					Return(emptyResult, emptyResponse, noError)
+			})
+
+			It("returns 200 OK, ignoring the command", func() {
+				handle()
+				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+			})
+		})
+	})
+
+	Context("with user being a collaborator", func() {
+		BeforeEach(func() {
+			repositories.
+				On("IsCollaborator", repositoryOwner, repositoryName, user).
+				Return(true, emptyResponse, noError)
+		})
+
+		test()
+	})
+}

--- a/github.go
+++ b/github.go
@@ -25,6 +25,7 @@ type PullRequests interface {
 type Repositories interface {
 	CreateStatus(owner, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error)
 	GetCombinedStatus(owner, repo, ref string, opt *github.ListOptions) (*github.CombinedStatus, *github.Response, error)
+	IsCollaborator(owner, repo, user string) (bool, *github.Response, error)
 }
 
 type Issues interface {
@@ -213,6 +214,11 @@ func comment(message string, repository Repository, issueNumber int, issues Issu
 	}
 	_, _, err := issues.CreateComment(repository.Owner, repository.Name, issueNumber, issueComment)
 	return err
+}
+
+func isCollaborator(repository Repository, user User, repositories Repositories) (bool, error) {
+	isCollab, _, err := repositories.IsCollaborator(repository.Owner, repository.Name, user.Login)
+	return isCollab, err
 }
 
 func is404Error(resp *github.Response) bool {

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -41,6 +42,7 @@ var (
 	emptyResult   = (interface{})(nil)
 	emptyResponse = &github.Response{Response: &http.Response{}}
 	noError       = (error)(nil)
+	errArbitrary  = errors.New("GitHub is down. Or something.")
 )
 
 func TestGithubReviewHelper(t *testing.T) {

--- a/mocks/Repositories.go
+++ b/mocks/Repositories.go
@@ -68,3 +68,31 @@ func (_m *Repositories) GetCombinedStatus(owner string, repo string, ref string,
 
 	return r0, r1, r2
 }
+func (_m *Repositories) IsCollaborator(owner string, repo string, user string) (bool, *github.Response, error) {
+	ret := _m.Called(owner, repo, user)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, string) bool); ok {
+		r0 = rf(owner, repo, user)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, string, string) *github.Response); ok {
+		r1 = rf(owner, repo, user)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, string) error); ok {
+		r2 = rf(owner, repo, user)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}


### PR DESCRIPTION
This has not been an issue for private repositories, where the access to
the PR comment thread is already limited, but for public repositories
this can be a real issue, if anybody can send the commands.

I suggest reviewing this diff with whitespace ignored. (with `?w=1` URL suffix on GitHub)