### PR TITLE
Use conditional requests for GitHub API calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,6 +120,9 @@ func initGithubClient(accessToken string) *github.Client {
 		MarkCachedResponses: true,
 	}
 
-	httpClient := &http.Client{Transport: memoryCacheTransport}
+	httpClient := &http.Client{
+		Transport: memoryCacheTransport,
+		Timeout:   30 * time.Second,
+	}
 	return github.NewClient(httpClient)
 }


### PR DESCRIPTION
GitHub API calls are rate limited to 5,000 requests per hour. GitHub
[suggests][1] using conditional requests wherever possible, because
these requests don't count against the rate limit, if the response is a
304 Not Modified. This is especially important for search queries
(currently performed on success status updates), because they have an
[even lower rate limit][2] of 30 requests per minute.

The go-github library doesn't support making conditional requests (and
therefore caching the results) directly, but [suggests][3] using the
httpcache library, which is exactly what this commit does.

This could've been implemented the other way around as well, so that the
httpcache Transport is used as a source Transport by the oauth2
Transport, but I'm not sure if there's a difference between the two
approaches. The only other implementation I could find online that
combined the same two libraries used a similar approach to the one taken
here.

[1]: https://developer.github.com/v3/#conditional-requests
[2]: https://developer.github.com/v3/search/#rate-limit
[3]: https://godoc.org/github.com/google/go-github/github#hdr-Conditional_Requests