### PR TITLE
Delay GitHub issue searches

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/deiwin/gonfigure"
 )
@@ -10,12 +11,15 @@ var (
 	portProperty        = gonfigure.NewEnvProperty("PORT", "80")
 	accessTokenProperty = gonfigure.NewRequiredEnvProperty("GITHUB_ACCESS_TOKEN")
 	secretProperty      = gonfigure.NewRequiredEnvProperty("GITHUB_SECRET")
+	// In the format defined in time.ParseDuration. E.g. "300ms", "-1.5h" or "2h45m".
+	githubAPIDelayProperty = gonfigure.NewEnvProperty("GITHUB_API_DELAY", "2s")
 )
 
 type Config struct {
-	Port        int
-	AccessToken string
-	Secret      string
+	Port           int
+	AccessToken    string
+	Secret         string
+	GithubAPIDelay time.Duration
 }
 
 func NewConfig() Config {
@@ -23,9 +27,16 @@ func NewConfig() Config {
 	if err != nil {
 		panic(err)
 	}
+
+	githubAPIDelay, err := time.ParseDuration(githubAPIDelayProperty.Value())
+	if err != nil {
+		panic(err)
+	}
+
 	return Config{
-		Port:        port,
-		AccessToken: accessTokenProperty.Value(),
-		Secret:      secretProperty.Value(),
+		Port:           port,
+		AccessToken:    accessTokenProperty.Value(),
+		Secret:         secretProperty.Value(),
+		GithubAPIDelay: githubAPIDelay,
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -9,11 +9,14 @@ type Handler func(http.ResponseWriter, *http.Request) Response
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	response := h(w, r)
+	log.Println("Responding to the HTTP request with:")
+	response.logResponse()
 	response.WriteResponse(w)
 }
 
 type Response interface {
 	WriteResponse(http.ResponseWriter)
+	logResponse()
 }
 
 type ErrorResponse struct {
@@ -23,12 +26,15 @@ type ErrorResponse struct {
 }
 
 func (r ErrorResponse) WriteResponse(w http.ResponseWriter) {
-	if r.Error != nil {
-		log.Printf("%s: %v\n", r.ErrorMessage, r.Error)
-	} else {
-		log.Println(r.ErrorMessage)
-	}
 	http.Error(w, r.ErrorMessage, r.Code)
+}
+
+func (r ErrorResponse) logResponse() {
+	if r.Error != nil {
+		log.Printf("Error: %s: %v\n", r.ErrorMessage, r.Error)
+	} else {
+		log.Printf("Error: %s\n", r.ErrorMessage)
+	}
 }
 
 type SuccessResponse struct {
@@ -36,6 +42,17 @@ type SuccessResponse struct {
 }
 
 func (r SuccessResponse) WriteResponse(w http.ResponseWriter) {
-	log.Printf("Responding with a success message: %s\n", r.Message)
 	w.Write([]byte(r.Message))
+}
+
+func (r SuccessResponse) logResponse() {
+	log.Printf("Success: %s\n", r.Message)
+}
+
+// handleAsyncResponse provides consistent error/success logging for operations
+// that are left to continue working after the original HTTP request that
+// initiated the operation has been handled and closed.
+func handleAsyncResponse(response Response) {
+	log.Println("Finishing an asynchronous operation with:")
+	response.logResponse()
 }

--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"sync"
 	"time"
 
@@ -191,10 +193,25 @@ func checkUserAuthorization(issueComment IssueComment, issues Issues, repositori
 }
 
 func delay(duration time.Duration, operation func() Response, asyncOperationWg *sync.WaitGroup) {
+	interruptChan := make(chan os.Signal, 1)
+	signal.Notify(interruptChan, os.Interrupt)
+
+	timer := time.NewTimer(duration)
+
 	asyncOperationWg.Add(1)
-	time.AfterFunc(duration, func() {
+	go func() {
 		defer asyncOperationWg.Done()
+		// Avoid leaking channels
+		defer signal.Stop(interruptChan)
+
+		// Block until either of the 2 channels receives.
+		select {
+		case <-interruptChan:
+			log.Println("Received an interrupt signal (SIGINT). Starting a scheduled process immediately.")
+		case <-timer.C:
+		}
+
 		response := operation()
 		handleAsyncResponse(response)
-	})
+	}()
 }

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -103,9 +103,11 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						mockSearchQuery(1).Return(emptyResult, emptyResponse, errors.New("arbitrary error"))
 					})
 
-					It("fails with a gateway error", func() {
+					// async errors are logged, but won't affect the outcome of
+					// the HTTP request
+					It("returns 200 OK", func() {
 						handle()
-						Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 					})
 				})
 
@@ -148,9 +150,11 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								Return(emptyResult, emptyResponse, errArbitrary)
 						})
 
-						It("fails with a gateway error", func() {
+						// async errors are logged, but won't affect the outcome of
+						// the HTTP request
+						It("returns 200 OK", func() {
 							handle()
-							Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+							Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 						})
 					})
 
@@ -176,7 +180,8 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								Return(pr, emptyResponse, noError)
 						})
 
-						ItMergesPR(context, pr)
+						isAsync := true
+						ItMergesPR(context, pr, isAsync)
 					})
 				})
 


### PR DESCRIPTION
Experience has shown that these searches can return outdated results
if run immediately on status update webhook events. This has caused some
PRs to get stuck in the merging state without being merged, because the
last status update event has already been sent, but the search during
that event did not show that the PR was ready to be merged. Because
there will be no additional events for that PR (unless users manually
use `!check`, for example) the PR will not get merged.

A simpler solution would have been to simply sleep for the specified
amount (2 seconds by default) and then do the search. But that approach
would mean that the GitHub webhook HTTP request and its connection is
unnecessarily kept open for the duration of the sleep + how long it then
takes to finish the search + merge. This is not too much of an issue for
the default 2 second delay, because Go's standard HTTP server handles
concurrency nicely, and even thousands of concurrent requests (even if
they're just sleeping) could be handled without a problem. However, if
it turns out that 2 seconds isn't sufficient, and a longer period has to
be used, then the described problem can start becoming an issue.
Furthermore, the async approach is much nicer towards GitHub webhook
service, which probably has to worry about too many connections that
stay open for too long already.

This approach does make the HTTP responses and tests a bit less
valuable, because neither can capture the final success/failure any
longer. Tests can still check that the async code sends all the right
requests to GitHub etc, but without parsing the logs or mocking the
delay mechanism, there's no way for the tests to verify the result.