### PR TITLE
Fix squash status race

### DIFF
--- a/check_command_test.go
+++ b/check_command_test.go
@@ -101,6 +101,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								},
 							},
 							&github.RepositoryCommit{
+								SHA: github.String(commitRevision),
 								Commit: &github.Commit{
 									Message: github.String("Another casual commit"),
 								},
@@ -158,6 +159,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						}).
 						Return([]*github.RepositoryCommit{
 							&github.RepositoryCommit{
+								SHA: github.String(commitRevision),
 								Commit: &github.Commit{
 									Message: github.String("fixup! Changing things\n\nOopsie. Forgot a thing"),
 								},

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -54,7 +54,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					BeforeEach(func() {
 						resp, err := createGithubErrorResponse(http.StatusNotFound)
 						pullRequests.
-							On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
+							On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
 							Return(emptyResult, resp, err)
 					})
 
@@ -74,7 +74,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					BeforeEach(func() {
 						resp, err := createGithubErrorResponse(http.StatusInternalServerError)
 						pullRequests.
-							On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
+							On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
 							Return(emptyResult, resp, err)
 					})
 
@@ -93,7 +93,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			Context("with list of commits from GitHub NOT including fixup commits", func() {
 				BeforeEach(func() {
 					pullRequests.
-						On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
+						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
 						Return([]*github.RepositoryCommit{
 							&github.RepositoryCommit{
 								Commit: &github.Commit{
@@ -108,7 +108,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							},
 						}, &github.Response{}, noError)
 					pullRequests.
-						On("Get", repositoryOwner, repositoryName, issueNumber).
+						On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 						Return(&github.PullRequest{
 							Number: github.Int(issueNumber),
 							Head: &github.PullRequestBranch{
@@ -123,7 +123,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				It("reports success status to GitHub", func() {
 					repositories.
-						On("CreateStatus", *headRepository.Owner.Login, *headRepository.Name, commitRevision,
+						On("CreateStatus", anyContext, *headRepository.Owner.Login, *headRepository.Name, commitRevision,
 							mock.MatchedBy(func(status *github.RepoStatus) bool {
 								return *status.State == "success" && *status.Context == "review/squash"
 							}),
@@ -139,7 +139,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			Context("with paged list of commits from GitHub including fixup commits", func() {
 				BeforeEach(func() {
 					pullRequests.
-						On("ListCommits", repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
+						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
 							Page:    1,
 							PerPage: 30,
 						}).
@@ -153,7 +153,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							NextPage: 2,
 						}, noError)
 					pullRequests.
-						On("ListCommits", repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
+						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
 							Page:    2,
 							PerPage: 30,
 						}).
@@ -166,7 +166,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							},
 						}, emptyResponse, noError)
 					pullRequests.
-						On("Get", repositoryOwner, repositoryName, issueNumber).
+						On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 						Return(&github.PullRequest{
 							Number: github.Int(issueNumber),
 							Head: &github.PullRequestBranch{
@@ -181,7 +181,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				It("reports pending squash status to GitHub", func() {
 					repositories.
-						On("CreateStatus", *headRepository.Owner.Login, *headRepository.Name, commitRevision,
+						On("CreateStatus", anyContext, *headRepository.Owner.Login, *headRepository.Name, commitRevision,
 							mock.MatchedBy(func(status *github.RepoStatus) bool {
 								return *status.State == "pending" && *status.Context == "review/squash"
 							}),

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -94,19 +94,10 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 				BeforeEach(func() {
 					pullRequests.
 						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
-						Return([]*github.RepositoryCommit{
-							&github.RepositoryCommit{
-								Commit: &github.Commit{
-									Message: github.String("Changing things"),
-								},
-							},
-							&github.RepositoryCommit{
-								SHA: github.String(commitRevision),
-								Commit: &github.Commit{
-									Message: github.String("Another casual commit"),
-								},
-							},
-						}, &github.Response{}, noError)
+						Return(githubCommits(
+							commit{arbitrarySHA, "Changing things"},
+							commit{commitRevision, "Another casual commit"},
+						), &github.Response{}, noError)
 					pullRequests.
 						On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 						Return(&github.PullRequest{
@@ -143,13 +134,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Page:    1,
 							PerPage: 30,
 						}).
-						Return([]*github.RepositoryCommit{
-							&github.RepositoryCommit{
-								Commit: &github.Commit{
-									Message: github.String("Changing things"),
-								},
-							},
-						}, &github.Response{
+						Return(githubCommits(
+							commit{arbitrarySHA, "Changing things"},
+						), &github.Response{
 							NextPage: 2,
 						}, noError)
 					pullRequests.
@@ -157,14 +144,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Page:    2,
 							PerPage: 30,
 						}).
-						Return([]*github.RepositoryCommit{
-							&github.RepositoryCommit{
-								SHA: github.String(commitRevision),
-								Commit: &github.Commit{
-									Message: github.String("fixup! Changing things\n\nOopsie. Forgot a thing"),
-								},
-							},
-						}, emptyResponse, noError)
+						Return(githubCommits(
+							commit{commitRevision, "fixup! Changing things\n\nOopsie. Forgot a thing"},
+						), emptyResponse, noError)
 					pullRequests.
 						On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 						Return(&github.PullRequest{

--- a/command_test.go
+++ b/command_test.go
@@ -28,7 +28,7 @@ func ForCollaborator(context WebhookTestContext, repoOwner, repoName, user strin
 	Context("with collaborator status check failing", func() {
 		BeforeEach(func() {
 			repositories.
-				On("IsCollaborator", repoOwner, repoName, user).
+				On("IsCollaborator", anyContext, repoOwner, repoName, user).
 				Return(false, emptyResponse, errArbitrary)
 		})
 
@@ -41,14 +41,14 @@ func ForCollaborator(context WebhookTestContext, repoOwner, repoName, user strin
 	Context("with user not being a collaborator", func() {
 		BeforeEach(func() {
 			repositories.
-				On("IsCollaborator", repoOwner, repoName, user).
+				On("IsCollaborator", anyContext, repoOwner, repoName, user).
 				Return(false, emptyResponse, noError)
 		})
 
 		Context("with sending a comment failing", func() {
 			BeforeEach(func() {
 				issues.
-					On("CreateComment", repoOwner, repoName,
+					On("CreateComment", anyContext, repoOwner, repoName,
 						issueNumber, mock.MatchedBy(commentMentioning(user))).
 					Return(emptyResult, emptyResponse, errArbitrary)
 			})
@@ -62,7 +62,7 @@ func ForCollaborator(context WebhookTestContext, repoOwner, repoName, user strin
 		Context("with sending a comment succeeding", func() {
 			BeforeEach(func() {
 				issues.
-					On("CreateComment", repoOwner, repoName,
+					On("CreateComment", anyContext, repoOwner, repoName,
 						issueNumber, mock.MatchedBy(commentMentioning(user))).
 					Return(emptyResult, emptyResponse, noError)
 			})
@@ -77,7 +77,7 @@ func ForCollaborator(context WebhookTestContext, repoOwner, repoName, user strin
 	Context("with user being a collaborator", func() {
 		BeforeEach(func() {
 			repositories.
-				On("IsCollaborator", repositoryOwner, repositoryName, user).
+				On("IsCollaborator", anyContext, repositoryOwner, repositoryName, user).
 				Return(true, emptyResponse, noError)
 		})
 

--- a/github.go
+++ b/github.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -17,25 +18,25 @@ var ErrNotMergeable = errors.New("PullRequests is not mergeable.")
 var ErrMergeConflict = errors.New("Merge failed because of a merge conflict.")
 
 type PullRequests interface {
-	Get(owner, repo string, number int) (*github.PullRequest, *github.Response, error)
-	ListCommits(owner, repo string, number int, opt *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error)
-	Merge(owner, repo string, number int, commitMessage string, opt *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error)
+	Get(ctx context.Context, owner, repo string, number int) (*github.PullRequest, *github.Response, error)
+	ListCommits(ctx context.Context, owner, repo string, number int, opt *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error)
+	Merge(ctx context.Context, owner, repo string, number int, commitMessage string, opt *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error)
 }
 
 type Repositories interface {
-	CreateStatus(owner, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error)
-	GetCombinedStatus(owner, repo, ref string, opt *github.ListOptions) (*github.CombinedStatus, *github.Response, error)
-	IsCollaborator(owner, repo, user string) (bool, *github.Response, error)
+	CreateStatus(ctx context.Context, owner, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error)
+	GetCombinedStatus(ctx context.Context, owner, repo, ref string, opt *github.ListOptions) (*github.CombinedStatus, *github.Response, error)
+	IsCollaborator(ctx context.Context, owner, repo, user string) (bool, *github.Response, error)
 }
 
 type Issues interface {
-	AddLabelsToIssue(owner, repo string, number int, labels []string) ([]*github.Label, *github.Response, error)
-	RemoveLabelForIssue(owner, repo string, number int, label string) (*github.Response, error)
-	CreateComment(owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
+	AddLabelsToIssue(ctx context.Context, owner, repo string, number int, labels []string) ([]*github.Label, *github.Response, error)
+	RemoveLabelForIssue(ctx context.Context, owner, repo string, number int, label string) (*github.Response, error)
+	CreateComment(ctx context.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
 }
 
 type Search interface {
-	Issues(query string, opt *github.SearchOptions) (*github.IssuesSearchResult, *github.Response, error)
+	Issues(ctx context.Context, query string, opt *github.SearchOptions) (*github.IssuesSearchResult, *github.Response, error)
 }
 
 func setStatusForPREvent(pullRequestEvent PullRequestEvent, status *github.RepoStatus, repositories Repositories) *ErrorResponse {
@@ -71,7 +72,7 @@ func setStatusForPR(pr *github.PullRequest, status *github.RepoStatus, repositor
 }
 
 func setStatus(revision string, repository Repository, status *github.RepoStatus, repositories Repositories) *ErrorResponse {
-	_, _, err := repositories.CreateStatus(repository.Owner, repository.Name, revision, status)
+	_, _, err := repositories.CreateStatus(context.TODO(), repository.Owner, repository.Name, revision, status)
 	if err != nil {
 		message := fmt.Sprintf("Failed to create a %s status for commit %s", *status.State, revision)
 		return &ErrorResponse{err, http.StatusBadGateway, message}
@@ -91,7 +92,8 @@ func getStatuses(pr *github.PullRequest, repositories Repositories) (string, []g
 			// https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
 			PerPage: 100,
 		}
-		combinedStatus, resp, err := repositories.GetCombinedStatus(headRepository.Owner, headRepository.Name, *pr.Head.SHA, listOptions)
+		combinedStatus, resp, err := repositories.GetCombinedStatus(context.TODO(), headRepository.Owner,
+			headRepository.Name, *pr.Head.SHA, listOptions)
 		if err != nil {
 			message := fmt.Sprintf("Failed to get combined status for ref %s", *pr.Head.SHA)
 			return "", nil, &ErrorResponse{err, http.StatusBadGateway, message}
@@ -120,7 +122,7 @@ func searchIssues(query string, search Search) ([]github.Issue, error) {
 		}
 		searchOptions := &github.SearchOptions{ListOptions: listOptions}
 
-		searchResult, resp, err := search.Issues(query, searchOptions)
+		searchResult, resp, err := search.Issues(context.TODO(), query, searchOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +138,7 @@ func searchIssues(query string, search Search) ([]github.Issue, error) {
 
 func getPR(issueable Issueable, pullRequests PullRequests) (*github.PullRequest, *ErrorResponse) {
 	issue := issueable.Issue()
-	pr, _, err := pullRequests.Get(issue.Repository.Owner, issue.Repository.Name, issue.Number)
+	pr, _, err := pullRequests.Get(context.TODO(), issue.Repository.Owner, issue.Repository.Name, issue.Number)
 	if err != nil {
 		message := fmt.Sprintf("Getting PR %s failed", issue.FullName())
 		return nil, &ErrorResponse{err, http.StatusBadGateway, message}
@@ -154,7 +156,8 @@ func getCommits(issueable Issueable, isExpectedHead func(string) bool, pullReque
 			Page:    pageNr,
 			PerPage: 30,
 		}
-		pageCommits, resp, err := pullRequests.ListCommits(issue.Repository.Owner, issue.Repository.Name, issue.Number, listOptions)
+		pageCommits, resp, err := pullRequests.ListCommits(context.TODO(), issue.Repository.Owner,
+			issue.Repository.Name, issue.Number, listOptions)
 		if err != nil {
 			if is404Error(resp) && nrOfRetriesLeft > 0 {
 				log.Printf("Getting commits for PR %s failed with a 404: \"%s\". Trying again.\n", issue.FullName(), err.Error())
@@ -199,7 +202,7 @@ func lastCommit(commits []*github.RepositoryCommit) *github.RepositoryCommit {
 }
 
 func addLabel(repository Repository, issueNumber int, label string, issues Issues) *ErrorResponse {
-	_, _, err := issues.AddLabelsToIssue(repository.Owner, repository.Name, issueNumber, []string{label})
+	_, _, err := issues.AddLabelsToIssue(context.TODO(), repository.Owner, repository.Name, issueNumber, []string{label})
 	if err != nil {
 		message := fmt.Sprintf("Failed to set the label %s for issue #%d", label, issueNumber)
 		return &ErrorResponse{err, http.StatusBadGateway, message}
@@ -208,7 +211,7 @@ func addLabel(repository Repository, issueNumber int, label string, issues Issue
 }
 
 func removeLabel(repository Repository, issueNumber int, label string, issues Issues) *ErrorResponse {
-	_, err := issues.RemoveLabelForIssue(repository.Owner, repository.Name, issueNumber, label)
+	_, err := issues.RemoveLabelForIssue(context.TODO(), repository.Owner, repository.Name, issueNumber, label)
 	if err != nil {
 		message := fmt.Sprintf("Failed to remove the label %s for issue #%d", label, issueNumber)
 		return &ErrorResponse{err, http.StatusBadGateway, message}
@@ -219,7 +222,8 @@ func removeLabel(repository Repository, issueNumber int, label string, issues Is
 func merge(repository Repository, issueNumber int, pullRequests PullRequests) error {
 	additionalCommitMessage := ""
 	opt := &github.PullRequestOptions{MergeMethod: "merge"}
-	result, resp, err := pullRequests.Merge(repository.Owner, repository.Name, issueNumber, additionalCommitMessage, opt)
+	result, resp, err := pullRequests.Merge(context.TODO(), repository.Owner, repository.Name,
+		issueNumber, additionalCommitMessage, opt)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusMethodNotAllowed {
 			return ErrNotMergeable
@@ -237,12 +241,12 @@ func comment(message string, repository Repository, issueNumber int, issues Issu
 	issueComment := &github.IssueComment{
 		Body: github.String(message),
 	}
-	_, _, err := issues.CreateComment(repository.Owner, repository.Name, issueNumber, issueComment)
+	_, _, err := issues.CreateComment(context.TODO(), repository.Owner, repository.Name, issueNumber, issueComment)
 	return err
 }
 
 func isCollaborator(repository Repository, user User, repositories Repositories) (bool, error) {
-	isCollab, _, err := repositories.IsCollaborator(repository.Owner, repository.Name, user.Login)
+	isCollab, _, err := repositories.IsCollaborator(context.TODO(), repository.Owner, repository.Name, user.Login)
 	return isCollab, err
 }
 

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -33,6 +33,7 @@ const (
 	sshURL               = "git@github.com:salemove/github-review-helper.git"
 	issueNumber          = 7
 	arbitraryIssueAuthor = "author"
+	arbitrarySHA         = "1afdea0acb09ff392fcdb89acfa9d7e9feac4bc1"
 )
 
 var (
@@ -246,4 +247,21 @@ var createStatusEvent = func(sha, state string, branches []grh.Branch) string {
     "ssh_url": "` + sshURL + `"
   }
 }`
+}
+
+type commit struct {
+	SHA, Message string
+}
+
+var githubCommits = func(commitList ...commit) []*github.RepositoryCommit {
+	githubCommitList := make([]*github.RepositoryCommit, len(commitList))
+	for i, commitData := range commitList {
+		githubCommitList[i] = &github.RepositoryCommit{
+			SHA: github.String(commitData.SHA),
+			Commit: &github.Commit{
+				Message: github.String(commitData.Message),
+			},
+		}
+	}
+	return githubCommitList
 }

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
@@ -17,6 +18,7 @@ import (
 	"github.com/google/go-github/github"
 	grh "github.com/salemove/github-review-helper"
 	"github.com/salemove/github-review-helper/mocks"
+	"github.com/stretchr/testify/mock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,6 +48,7 @@ var (
 	emptyResponse = &github.Response{Response: &http.Response{}}
 	noError       = (error)(nil)
 	errArbitrary  = errors.New("GitHub is down. Or something.")
+	anyContext    = mock.MatchedBy(func(ctx context.Context) bool { return true })
 )
 
 func TestGithubReviewHelper(t *testing.T) {

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -93,7 +93,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					searchQuery := fmt.Sprintf("%s label:\"%s\" is:open repo:%s/%s status:success",
 						mockSHA, grh.MergingLabel, repositoryOwner, repositoryName)
 					return search.
-						On("Issues", searchQuery, mock.MatchedBy(func(searchOptions *github.SearchOptions) bool {
+						On("Issues", anyContext, searchQuery, mock.MatchedBy(func(searchOptions *github.SearchOptions) bool {
 							return searchOptions.Page == pageNr
 						}))
 				}
@@ -146,7 +146,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					Context("with GitHub API request for that PR failing", func() {
 						BeforeEach(func() {
 							pullRequests.
-								On("Get", repositoryOwner, repositoryName, issueNumber).
+								On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 								Return(emptyResult, emptyResponse, errArbitrary)
 						})
 
@@ -176,7 +176,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 						BeforeEach(func() {
 							pullRequests.
-								On("Get", repositoryOwner, repositoryName, issueNumber).
+								On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 								Return(pr, emptyResponse, noError)
 						})
 
@@ -209,7 +209,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							},
 						}
 						pullRequests.
-							On("Get", repositoryOwner, repositoryName, number).
+							On("Get", anyContext, repositoryOwner, repositoryName, number).
 							Return(pr, emptyResponse, noError).
 							Once()
 						// Merge
@@ -217,6 +217,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						pullRequests.
 							On(
 								"Merge",
+								anyContext,
 								repositoryOwner,
 								repositoryName,
 								number,
@@ -229,7 +230,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Once()
 						// Remove label
 						issues.
-							On("RemoveLabelForIssue", repositoryOwner, repositoryName, number, grh.MergingLabel).
+							On("RemoveLabelForIssue", anyContext, repositoryOwner, repositoryName, number, grh.MergingLabel).
 							Return(emptyResponse, noError).
 							Once()
 						// Delete branch

--- a/mocks/Issues.go
+++ b/mocks/Issues.go
@@ -2,18 +2,20 @@ package mocks
 
 import "github.com/stretchr/testify/mock"
 
+import "context"
+
 import "github.com/google/go-github/github"
 
 type Issues struct {
 	mock.Mock
 }
 
-func (_m *Issues) AddLabelsToIssue(owner string, repo string, number int, labels []string) ([]*github.Label, *github.Response, error) {
-	ret := _m.Called(owner, repo, number, labels)
+func (_m *Issues) AddLabelsToIssue(ctx context.Context, owner string, repo string, number int, labels []string) ([]*github.Label, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, number, labels)
 
 	var r0 []*github.Label
-	if rf, ok := ret.Get(0).(func(string, string, int, []string) []*github.Label); ok {
-		r0 = rf(owner, repo, number, labels)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, []string) []*github.Label); ok {
+		r0 = rf(ctx, owner, repo, number, labels)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*github.Label)
@@ -21,8 +23,8 @@ func (_m *Issues) AddLabelsToIssue(owner string, repo string, number int, labels
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, int, []string) *github.Response); ok {
-		r1 = rf(owner, repo, number, labels)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int, []string) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, number, labels)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -30,20 +32,20 @@ func (_m *Issues) AddLabelsToIssue(owner string, repo string, number int, labels
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, int, []string) error); ok {
-		r2 = rf(owner, repo, number, labels)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, int, []string) error); ok {
+		r2 = rf(ctx, owner, repo, number, labels)
 	} else {
 		r2 = ret.Error(2)
 	}
 
 	return r0, r1, r2
 }
-func (_m *Issues) RemoveLabelForIssue(owner string, repo string, number int, label string) (*github.Response, error) {
-	ret := _m.Called(owner, repo, number, label)
+func (_m *Issues) RemoveLabelForIssue(ctx context.Context, owner string, repo string, number int, label string) (*github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, number, label)
 
 	var r0 *github.Response
-	if rf, ok := ret.Get(0).(func(string, string, int, string) *github.Response); ok {
-		r0 = rf(owner, repo, number, label)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, string) *github.Response); ok {
+		r0 = rf(ctx, owner, repo, number, label)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*github.Response)
@@ -51,20 +53,20 @@ func (_m *Issues) RemoveLabelForIssue(owner string, repo string, number int, lab
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, int, string) error); ok {
-		r1 = rf(owner, repo, number, label)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int, string) error); ok {
+		r1 = rf(ctx, owner, repo, number, label)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
 }
-func (_m *Issues) CreateComment(owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
-	ret := _m.Called(owner, repo, number, comment)
+func (_m *Issues) CreateComment(ctx context.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, number, comment)
 
 	var r0 *github.IssueComment
-	if rf, ok := ret.Get(0).(func(string, string, int, *github.IssueComment) *github.IssueComment); ok {
-		r0 = rf(owner, repo, number, comment)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, *github.IssueComment) *github.IssueComment); ok {
+		r0 = rf(ctx, owner, repo, number, comment)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*github.IssueComment)
@@ -72,8 +74,8 @@ func (_m *Issues) CreateComment(owner string, repo string, number int, comment *
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, int, *github.IssueComment) *github.Response); ok {
-		r1 = rf(owner, repo, number, comment)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int, *github.IssueComment) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, number, comment)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -81,8 +83,8 @@ func (_m *Issues) CreateComment(owner string, repo string, number int, comment *
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, int, *github.IssueComment) error); ok {
-		r2 = rf(owner, repo, number, comment)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, int, *github.IssueComment) error); ok {
+		r2 = rf(ctx, owner, repo, number, comment)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/mocks/PullRequests.go
+++ b/mocks/PullRequests.go
@@ -2,18 +2,20 @@ package mocks
 
 import "github.com/stretchr/testify/mock"
 
+import "context"
+
 import "github.com/google/go-github/github"
 
 type PullRequests struct {
 	mock.Mock
 }
 
-func (_m *PullRequests) Get(owner string, repo string, number int) (*github.PullRequest, *github.Response, error) {
-	ret := _m.Called(owner, repo, number)
+func (_m *PullRequests) Get(ctx context.Context, owner string, repo string, number int) (*github.PullRequest, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, number)
 
 	var r0 *github.PullRequest
-	if rf, ok := ret.Get(0).(func(string, string, int) *github.PullRequest); ok {
-		r0 = rf(owner, repo, number)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) *github.PullRequest); ok {
+		r0 = rf(ctx, owner, repo, number)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*github.PullRequest)
@@ -21,8 +23,8 @@ func (_m *PullRequests) Get(owner string, repo string, number int) (*github.Pull
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, int) *github.Response); ok {
-		r1 = rf(owner, repo, number)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, number)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -30,20 +32,20 @@ func (_m *PullRequests) Get(owner string, repo string, number int) (*github.Pull
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, int) error); ok {
-		r2 = rf(owner, repo, number)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, int) error); ok {
+		r2 = rf(ctx, owner, repo, number)
 	} else {
 		r2 = ret.Error(2)
 	}
 
 	return r0, r1, r2
 }
-func (_m *PullRequests) ListCommits(owner string, repo string, number int, opt *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
-	ret := _m.Called(owner, repo, number, opt)
+func (_m *PullRequests) ListCommits(ctx context.Context, owner string, repo string, number int, opt *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, number, opt)
 
 	var r0 []*github.RepositoryCommit
-	if rf, ok := ret.Get(0).(func(string, string, int, *github.ListOptions) []*github.RepositoryCommit); ok {
-		r0 = rf(owner, repo, number, opt)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, *github.ListOptions) []*github.RepositoryCommit); ok {
+		r0 = rf(ctx, owner, repo, number, opt)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*github.RepositoryCommit)
@@ -51,8 +53,8 @@ func (_m *PullRequests) ListCommits(owner string, repo string, number int, opt *
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, int, *github.ListOptions) *github.Response); ok {
-		r1 = rf(owner, repo, number, opt)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int, *github.ListOptions) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, number, opt)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -60,20 +62,20 @@ func (_m *PullRequests) ListCommits(owner string, repo string, number int, opt *
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, int, *github.ListOptions) error); ok {
-		r2 = rf(owner, repo, number, opt)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, int, *github.ListOptions) error); ok {
+		r2 = rf(ctx, owner, repo, number, opt)
 	} else {
 		r2 = ret.Error(2)
 	}
 
 	return r0, r1, r2
 }
-func (_m *PullRequests) Merge(owner string, repo string, number int, commitMessage string, opt *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error) {
-	ret := _m.Called(owner, repo, number, commitMessage, opt)
+func (_m *PullRequests) Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, opt *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, number, commitMessage, opt)
 
 	var r0 *github.PullRequestMergeResult
-	if rf, ok := ret.Get(0).(func(string, string, int, string, *github.PullRequestOptions) *github.PullRequestMergeResult); ok {
-		r0 = rf(owner, repo, number, commitMessage, opt)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, string, *github.PullRequestOptions) *github.PullRequestMergeResult); ok {
+		r0 = rf(ctx, owner, repo, number, commitMessage, opt)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*github.PullRequestMergeResult)
@@ -81,8 +83,8 @@ func (_m *PullRequests) Merge(owner string, repo string, number int, commitMessa
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, int, string, *github.PullRequestOptions) *github.Response); ok {
-		r1 = rf(owner, repo, number, commitMessage, opt)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int, string, *github.PullRequestOptions) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, number, commitMessage, opt)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -90,8 +92,8 @@ func (_m *PullRequests) Merge(owner string, repo string, number int, commitMessa
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, int, string, *github.PullRequestOptions) error); ok {
-		r2 = rf(owner, repo, number, commitMessage, opt)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, int, string, *github.PullRequestOptions) error); ok {
+		r2 = rf(ctx, owner, repo, number, commitMessage, opt)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/mocks/Repositories.go
+++ b/mocks/Repositories.go
@@ -2,18 +2,20 @@ package mocks
 
 import "github.com/stretchr/testify/mock"
 
+import "context"
+
 import "github.com/google/go-github/github"
 
 type Repositories struct {
 	mock.Mock
 }
 
-func (_m *Repositories) CreateStatus(owner string, repo string, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
-	ret := _m.Called(owner, repo, ref, status)
+func (_m *Repositories) CreateStatus(ctx context.Context, owner string, repo string, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, ref, status)
 
 	var r0 *github.RepoStatus
-	if rf, ok := ret.Get(0).(func(string, string, string, *github.RepoStatus) *github.RepoStatus); ok {
-		r0 = rf(owner, repo, ref, status)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *github.RepoStatus) *github.RepoStatus); ok {
+		r0 = rf(ctx, owner, repo, ref, status)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*github.RepoStatus)
@@ -21,8 +23,8 @@ func (_m *Repositories) CreateStatus(owner string, repo string, ref string, stat
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, string, *github.RepoStatus) *github.Response); ok {
-		r1 = rf(owner, repo, ref, status)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, *github.RepoStatus) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, ref, status)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -30,20 +32,20 @@ func (_m *Repositories) CreateStatus(owner string, repo string, ref string, stat
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, string, *github.RepoStatus) error); ok {
-		r2 = rf(owner, repo, ref, status)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, *github.RepoStatus) error); ok {
+		r2 = rf(ctx, owner, repo, ref, status)
 	} else {
 		r2 = ret.Error(2)
 	}
 
 	return r0, r1, r2
 }
-func (_m *Repositories) GetCombinedStatus(owner string, repo string, ref string, opt *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
-	ret := _m.Called(owner, repo, ref, opt)
+func (_m *Repositories) GetCombinedStatus(ctx context.Context, owner string, repo string, ref string, opt *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, ref, opt)
 
 	var r0 *github.CombinedStatus
-	if rf, ok := ret.Get(0).(func(string, string, string, *github.ListOptions) *github.CombinedStatus); ok {
-		r0 = rf(owner, repo, ref, opt)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *github.ListOptions) *github.CombinedStatus); ok {
+		r0 = rf(ctx, owner, repo, ref, opt)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*github.CombinedStatus)
@@ -51,8 +53,8 @@ func (_m *Repositories) GetCombinedStatus(owner string, repo string, ref string,
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, string, *github.ListOptions) *github.Response); ok {
-		r1 = rf(owner, repo, ref, opt)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, *github.ListOptions) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, ref, opt)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -60,27 +62,27 @@ func (_m *Repositories) GetCombinedStatus(owner string, repo string, ref string,
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, string, *github.ListOptions) error); ok {
-		r2 = rf(owner, repo, ref, opt)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, *github.ListOptions) error); ok {
+		r2 = rf(ctx, owner, repo, ref, opt)
 	} else {
 		r2 = ret.Error(2)
 	}
 
 	return r0, r1, r2
 }
-func (_m *Repositories) IsCollaborator(owner string, repo string, user string) (bool, *github.Response, error) {
-	ret := _m.Called(owner, repo, user)
+func (_m *Repositories) IsCollaborator(ctx context.Context, owner string, repo string, user string) (bool, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, user)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(string, string, string) bool); ok {
-		r0 = rf(owner, repo, user)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) bool); ok {
+		r0 = rf(ctx, owner, repo, user)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, string, string) *github.Response); ok {
-		r1 = rf(owner, repo, user)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, user)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -88,8 +90,8 @@ func (_m *Repositories) IsCollaborator(owner string, repo string, user string) (
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, string, string) error); ok {
-		r2 = rf(owner, repo, user)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, string) error); ok {
+		r2 = rf(ctx, owner, repo, user)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/mocks/Search.go
+++ b/mocks/Search.go
@@ -2,18 +2,20 @@ package mocks
 
 import "github.com/stretchr/testify/mock"
 
+import "context"
+
 import "github.com/google/go-github/github"
 
 type Search struct {
 	mock.Mock
 }
 
-func (_m *Search) Issues(query string, opt *github.SearchOptions) (*github.IssuesSearchResult, *github.Response, error) {
-	ret := _m.Called(query, opt)
+func (_m *Search) Issues(ctx context.Context, query string, opt *github.SearchOptions) (*github.IssuesSearchResult, *github.Response, error) {
+	ret := _m.Called(ctx, query, opt)
 
 	var r0 *github.IssuesSearchResult
-	if rf, ok := ret.Get(0).(func(string, *github.SearchOptions) *github.IssuesSearchResult); ok {
-		r0 = rf(query, opt)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *github.SearchOptions) *github.IssuesSearchResult); ok {
+		r0 = rf(ctx, query, opt)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*github.IssuesSearchResult)
@@ -21,8 +23,8 @@ func (_m *Search) Issues(query string, opt *github.SearchOptions) (*github.Issue
 	}
 
 	var r1 *github.Response
-	if rf, ok := ret.Get(1).(func(string, *github.SearchOptions) *github.Response); ok {
-		r1 = rf(query, opt)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *github.SearchOptions) *github.Response); ok {
+		r1 = rf(ctx, query, opt)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*github.Response)
@@ -30,8 +32,8 @@ func (_m *Search) Issues(query string, opt *github.SearchOptions) (*github.Issue
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, *github.SearchOptions) error); ok {
-		r2 = rf(query, opt)
+	if rf, ok := ret.Get(2).(func(context.Context, string, *github.SearchOptions) error); ok {
+		r2 = rf(ctx, query, opt)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pull_request_event_test.go
+++ b/pull_request_event_test.go
@@ -116,19 +116,10 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 				BeforeEach(func() {
 					pullRequests.
 						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
-						Return([]*github.RepositoryCommit{
-							&github.RepositoryCommit{
-								Commit: &github.Commit{
-									Message: github.String("Changing things"),
-								},
-							},
-							&github.RepositoryCommit{
-								SHA: github.String(headCommitRevision),
-								Commit: &github.Commit{
-									Message: github.String("Another casual commit"),
-								},
-							},
-						}, emptyResponse, noError)
+						Return(githubCommits(
+							commit{arbitrarySHA, "Changing things"},
+							commit{headCommitRevision, "Another casual commit"},
+						), emptyResponse, noError)
 				})
 
 				It("fails with a gateway error", func() {
@@ -147,19 +138,10 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 				BeforeEach(func() {
 					pullRequests.
 						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
-						Return([]*github.RepositoryCommit{
-							&github.RepositoryCommit{
-								Commit: &github.Commit{
-									Message: github.String("Changing things"),
-								},
-							},
-							&github.RepositoryCommit{
-								SHA: github.String(pullRequestHeadSHA),
-								Commit: &github.Commit{
-									Message: github.String("Another casual commit"),
-								},
-							},
-						}, emptyResponse, noError)
+						Return(githubCommits(
+							commit{arbitrarySHA, "Changing things"},
+							commit{pullRequestHeadSHA, "Another casual commit"},
+						), emptyResponse, noError)
 				})
 
 				It("reports success status to GitHub", func() {
@@ -184,13 +166,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Page:    1,
 							PerPage: 30,
 						}).
-						Return([]*github.RepositoryCommit{
-							&github.RepositoryCommit{
-								Commit: &github.Commit{
-									Message: github.String("Changing things"),
-								},
-							},
-						}, &github.Response{
+						Return(githubCommits(
+							commit{arbitrarySHA, "Changing things"},
+						), &github.Response{
 							NextPage: 2,
 						}, noError)
 					pullRequests.
@@ -198,14 +176,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Page:    2,
 							PerPage: 30,
 						}).
-						Return([]*github.RepositoryCommit{
-							&github.RepositoryCommit{
-								SHA: github.String(pullRequestHeadSHA),
-								Commit: &github.Commit{
-									Message: github.String("fixup! Changing things\n\nOopsie. Forgot a thing"),
-								},
-							},
-						}, &github.Response{}, noError)
+						Return(githubCommits(
+							commit{pullRequestHeadSHA, "fixup! Changing things\n\nOopsie. Forgot a thing"},
+						), &github.Response{}, noError)
 				})
 
 				It("reports pending squash status to GitHub", func() {

--- a/pull_request_event_test.go
+++ b/pull_request_event_test.go
@@ -75,7 +75,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					BeforeEach(func() {
 						resp, err := createGithubErrorResponse(http.StatusNotFound)
 						pullRequests.
-							On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
+							On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
 							Return(emptyResult, resp, err)
 					})
 
@@ -94,7 +94,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 				Context("with a different error", func() {
 					BeforeEach(func() {
 						pullRequests.
-							On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
+							On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
 							Return(emptyResult, emptyResponse, errors.New("an error"))
 					})
 
@@ -115,7 +115,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				BeforeEach(func() {
 					pullRequests.
-						On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
+						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
 						Return([]*github.RepositoryCommit{
 							&github.RepositoryCommit{
 								Commit: &github.Commit{
@@ -146,7 +146,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			Context("with list of commits from GitHub NOT including fixup commits", func() {
 				BeforeEach(func() {
 					pullRequests.
-						On("ListCommits", repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
+						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, mock.AnythingOfType("*github.ListOptions")).
 						Return([]*github.RepositoryCommit{
 							&github.RepositoryCommit{
 								Commit: &github.Commit{
@@ -164,7 +164,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				It("reports success status to GitHub", func() {
 					repositories.
-						On("CreateStatus", headRepository.Owner, headRepository.Name, pullRequestHeadSHA,
+						On("CreateStatus", anyContext, headRepository.Owner, headRepository.Name, pullRequestHeadSHA,
 							mock.MatchedBy(func(status *github.RepoStatus) bool {
 								return *status.State == "success" && *status.Context == "review/squash"
 							}),
@@ -180,7 +180,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			Context("with paged list of commits from GitHub including fixup commits", func() {
 				BeforeEach(func() {
 					pullRequests.
-						On("ListCommits", repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
+						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
 							Page:    1,
 							PerPage: 30,
 						}).
@@ -194,7 +194,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							NextPage: 2,
 						}, noError)
 					pullRequests.
-						On("ListCommits", repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
+						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
 							Page:    2,
 							PerPage: 30,
 						}).
@@ -210,7 +210,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				It("reports pending squash status to GitHub", func() {
 					repositories.
-						On("CreateStatus", headRepository.Owner, headRepository.Name, pullRequestHeadSHA,
+						On("CreateStatus", anyContext, headRepository.Owner, headRepository.Name, pullRequestHeadSHA,
 							mock.MatchedBy(func(status *github.RepoStatus) bool {
 								return *status.State == "pending" && *status.Context == "review/squash"
 							}),

--- a/squash_command_test.go
+++ b/squash_command_test.go
@@ -42,7 +42,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			Context("with GitHub request failing", func() {
 				BeforeEach(func() {
 					pullRequests.
-						On("Get", repositoryOwner, repositoryName, issueNumber).
+						On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 						Return(emptyResult, emptyResponse, errors.New("an error"))
 				})
 
@@ -69,7 +69,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 				BeforeEach(func() {
 					pullRequests.
-						On("Get", repositoryOwner, repositoryName, issueNumber).
+						On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 						Return(pr, emptyResponse, noError)
 				})
 
@@ -118,7 +118,7 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 
 		It("reports the failure", func() {
 			repositories.
-				On("CreateStatus", repositoryOwner, repositoryName, headSHA, mock.MatchedBy(func(status *github.RepoStatus) bool {
+				On("CreateStatus", anyContext, repositoryOwner, repositoryName, headSHA, mock.MatchedBy(func(status *github.RepoStatus) bool {
 					return *status.State == "failure" && *status.Context == "review/squash"
 				})).
 				Return(emptyResult, emptyResponse, noError)


### PR DESCRIPTION
This fixes, for example, the scenario described in 6a37b24. Essentially,
when requesting commits for a PR then if the PR has been recently
updated then GitHub API may return an outdated list. This means that
checking for fixup commits in that list may return a false response.

One similar race condition was fixed in b421821, where the outdated list
of commits meant no commits, but it didn't fix the scenario where the
outdated list meant a whole different set of commits.

This is only implemented for PullRequestEvents and not for the `!check`
command (IssueCommentEvents), because PullRequestEvents contain the head
SHA that is guaranteed to be up to date, whereas the IssueCommentEvents
don't. But this should not be an issue, because the `!check` command is
sent by comments written by actual users - events which are decoupled
from the git/GitHub events which may change the commit list. The
decoupling means that the race condition is unlikely to happen in these
cases.