### PR TITLE
Fix head commit check relying on GitHub response order

### DIFF
--- a/check_command_test.go
+++ b/check_command_test.go
@@ -129,24 +129,12 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 			Context("with paged list of commits from GitHub including fixup commits", func() {
 				BeforeEach(func() {
-					pullRequests.
-						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
-							Page:    1,
-							PerPage: 30,
-						}).
-						Return(githubCommits(
-							commit{arbitrarySHA, "Changing things"},
-						), &github.Response{
-							NextPage: 2,
-						}, noError)
-					pullRequests.
-						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
-							Page:    2,
-							PerPage: 30,
-						}).
-						Return(githubCommits(
-							commit{commitRevision, "fixup! Changing things\n\nOopsie. Forgot a thing"},
-						), emptyResponse, noError)
+					perPage := 1
+					commits := githubCommits(
+						commit{arbitrarySHA, "Changing things"},
+						commit{commitRevision, "fixup! Changing things\n\nOopsie. Forgot a thing"},
+					)
+					mockListCommits(commits, perPage, repositoryOwner, repositoryName, issueNumber, pullRequests)
 					pullRequests.
 						On("Get", anyContext, repositoryOwner, repositoryName, issueNumber).
 						Return(&github.PullRequest{

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -253,6 +253,12 @@ type commit struct {
 	SHA, Message string
 }
 
+// arbitraryParentSHA is a SHA different from arbitrarySHA, to avoid cycles
+// and other issues in the commit list.
+const arbitraryParentSHA = "43c3c0c406518f3f326474f9e378027f86f27caf"
+
+// githubCommits returns an ordered list of github commits, where the HEAD
+// commit is the last one in the list.
 var githubCommits = func(commitList ...commit) []*github.RepositoryCommit {
 	githubCommitList := make([]*github.RepositoryCommit, len(commitList))
 	for i, commitData := range commitList {
@@ -262,6 +268,25 @@ var githubCommits = func(commitList ...commit) []*github.RepositoryCommit {
 				Message: github.String(commitData.Message),
 			},
 		}
+		if i > 0 {
+			githubCommitList[i].Parents = []github.Commit{
+				github.Commit{SHA: githubCommitList[i-1].SHA},
+			}
+		} else {
+			githubCommitList[i].Parents = []github.Commit{
+				github.Commit{SHA: github.String(arbitraryParentSHA)},
+			}
+		}
+	}
+	return githubCommitList
+}
+
+var githubCommitsInMixedOrder = func(commitList ...commit) []*github.RepositoryCommit {
+	githubCommitList := githubCommits(commitList...)
+	if len(githubCommitList) > 1 {
+		// swap 2 last elements
+		lastIndex := len(githubCommitList) - 1
+		githubCommitList[lastIndex], githubCommitList[lastIndex-1] = githubCommitList[lastIndex-1], githubCommitList[lastIndex]
 	}
 	return githubCommitList
 }

--- a/pull_request_event_test.go
+++ b/pull_request_event_test.go
@@ -161,24 +161,12 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 			Context("with paged list of commits from GitHub including fixup commits", func() {
 				BeforeEach(func() {
-					pullRequests.
-						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
-							Page:    1,
-							PerPage: 30,
-						}).
-						Return(githubCommits(
-							commit{arbitrarySHA, "Changing things"},
-						), &github.Response{
-							NextPage: 2,
-						}, noError)
-					pullRequests.
-						On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
-							Page:    2,
-							PerPage: 30,
-						}).
-						Return(githubCommits(
-							commit{pullRequestHeadSHA, "fixup! Changing things\n\nOopsie. Forgot a thing"},
-						), &github.Response{}, noError)
+					perPage := 1
+					commits := githubCommits(
+						commit{arbitrarySHA, "Changing things"},
+						commit{pullRequestHeadSHA, "fixup! Changing things\n\nOopsie. Forgot a thing"},
+					)
+					mockListCommits(commits, perPage, repositoryOwner, repositoryName, issueNumber, pullRequests)
 				})
 
 				It("reports pending squash status to GitHub", func() {


### PR DESCRIPTION
GitHub returns the commits in chronological order, which means that the
assumption that the last commit is the HEAD commit was wrong. The
assumption works in most cases, but some rebasing can easily mess up the
ordering and break the current check.

The fix is to find the HEAD based on the topological ordering provided
by the commits' parent references.