### PR TITLE
Better manage GitHub API eventual consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: go
+go:
+  - 1.x
 sudo: false

--- a/async.go
+++ b/async.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func delay(duration time.Duration, operation func() Response, asyncOperationWg *sync.WaitGroup) {
+func delay(duration time.Duration, operation func(), asyncOperationWg *sync.WaitGroup) {
 	interruptChan := make(chan os.Signal, 1)
 	signal.Notify(interruptChan, os.Interrupt)
 
@@ -27,7 +27,6 @@ func delay(duration time.Duration, operation func() Response, asyncOperationWg *
 		case <-timer.C:
 		}
 
-		response := operation()
-		handleAsyncResponse(response)
+		operation()
 	}()
 }

--- a/async.go
+++ b/async.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+)
+
+func delay(duration time.Duration, operation func() Response, asyncOperationWg *sync.WaitGroup) {
+	interruptChan := make(chan os.Signal, 1)
+	signal.Notify(interruptChan, os.Interrupt)
+
+	timer := time.NewTimer(duration)
+
+	asyncOperationWg.Add(1)
+	go func() {
+		defer asyncOperationWg.Done()
+		// Avoid leaking channels
+		defer signal.Stop(interruptChan)
+
+		// Block until either of the 2 channels receives.
+		select {
+		case <-interruptChan:
+			log.Println("Received an interrupt signal (SIGINT). Starting a scheduled process immediately.")
+		case <-timer.C:
+		}
+
+		response := operation()
+		handleAsyncResponse(response)
+	}()
+}

--- a/async.go
+++ b/async.go
@@ -15,6 +15,11 @@ type asyncResponse struct {
 	MayBeRetried bool
 }
 
+type asyncErrorResponse struct {
+	ErrorResponse
+	MayBeRetried bool
+}
+
 // MaybeSyncResponse can be returned from operations which may or may not
 // complete synchronously. When OperationFinishedSynchronously is true, then
 // Response will be specified.
@@ -111,5 +116,26 @@ func nonRetriable(response Response) asyncResponse {
 	return asyncResponse{
 		Response:     response,
 		MayBeRetried: false,
+	}
+}
+
+func retriableError(errResp ErrorResponse) *asyncErrorResponse {
+	return &asyncErrorResponse{
+		ErrorResponse: errResp,
+		MayBeRetried:  true,
+	}
+}
+
+func nonRetriableError(errResp ErrorResponse) *asyncErrorResponse {
+	return &asyncErrorResponse{
+		ErrorResponse: errResp,
+		MayBeRetried:  false,
+	}
+}
+
+func (a asyncErrorResponse) toAsyncResponse() asyncResponse {
+	return asyncResponse{
+		Response:     a.ErrorResponse,
+		MayBeRetried: a.MayBeRetried,
 	}
 }

--- a/async.go
+++ b/async.go
@@ -99,3 +99,17 @@ func delay(duration time.Duration, operation func(), asyncOperationWg *sync.Wait
 		operation()
 	}()
 }
+
+func retriable(response Response) asyncResponse {
+	return asyncResponse{
+		Response:     response,
+		MayBeRetried: true,
+	}
+}
+
+func nonRetriable(response Response) asyncResponse {
+	return asyncResponse{
+		Response:     response,
+		MayBeRetried: false,
+	}
+}

--- a/async.go
+++ b/async.go
@@ -1,12 +1,40 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 	"os/signal"
 	"sync"
 	"time"
 )
+
+type asyncResponse struct {
+	Response
+	MayBeRetried bool
+}
+
+func delayWithRetries(tryDelays []time.Duration, operation func() asyncResponse,
+	asyncOperationWg *sync.WaitGroup) error {
+
+	if len(tryDelays) < 1 {
+		return errors.New("Cannot schedule any delayed operations when tryDelays is empty")
+	}
+
+	delay(tryDelays[0], func() {
+		response := operation()
+		handleAsyncResponse(response.Response)
+		if len(tryDelays) > 1 && response.MayBeRetried {
+			log.Println("Operation will be retried")
+			if err := delayWithRetries(tryDelays[1:], operation, asyncOperationWg); err != nil {
+				log.Printf("Failed to schedule another try to start in %s\n", tryDelays[1].String())
+				return
+			}
+		}
+	}, asyncOperationWg)
+	log.Printf("Scheduled an asynchronous operation to start in %s\n", tryDelays[0].String())
+	return nil
+}
 
 func delay(duration time.Duration, operation func(), asyncOperationWg *sync.WaitGroup) {
 	interruptChan := make(chan os.Signal, 1)

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 
 	"github.com/google/go-github/github"
-	grh "github.com/salemove/github-review-helper"
 	"github.com/salemove/github-review-helper/mocks"
 	"github.com/stretchr/testify/mock"
 
@@ -58,15 +57,15 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Return(emptyResult, resp, err)
 					})
 
-					It("fails with a gateway error", func() {
+					// Responds with 200, because the operation will be retries asynchronously
+					It("responds with 200 OK", func() {
 						handle()
-						Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 					})
 
-					It("tries multiple times", func() {
+					It("tries the configured amount of times", func() {
 						handle()
-						// +1 because of the initial attempt
-						pullRequests.AssertNumberOfCalls(GinkgoT(), "ListCommits", grh.GetCommitsRetryLimit+1)
+						pullRequests.AssertNumberOfCalls(GinkgoT(), "ListCommits", numberOfGithubTries)
 					})
 				})
 

--- a/config.go
+++ b/config.go
@@ -15,7 +15,9 @@ var (
 	accessTokenProperty = gonfigure.NewRequiredEnvProperty("GITHUB_ACCESS_TOKEN")
 	secretProperty      = gonfigure.NewRequiredEnvProperty("GITHUB_SECRET")
 	// A comma separated list of durations in the format defined in
-	// time.ParseDuration. E.g. "300ms,1.5h,2h45m".
+	// time.ParseDuration. E.g. "300ms,1.5h,2h45m". When first duration is 0,
+	// then GitHub API requests will initially be tried synchronously and only
+	// the retries will be asynchronous.
 	githubAPITriesProperty = gonfigure.NewEnvProperty("GITHUB_API_TRIES", "0s,10s,30s,3m")
 )
 

--- a/config.go
+++ b/config.go
@@ -14,8 +14,6 @@ var (
 	portProperty        = gonfigure.NewEnvProperty("PORT", "80")
 	accessTokenProperty = gonfigure.NewRequiredEnvProperty("GITHUB_ACCESS_TOKEN")
 	secretProperty      = gonfigure.NewRequiredEnvProperty("GITHUB_SECRET")
-	// In the format defined in time.ParseDuration. E.g. "300ms", "-1.5h" or "2h45m".
-	githubAPIDelayProperty = gonfigure.NewEnvProperty("GITHUB_API_DELAY", "2s")
 	// A comma separated list of durations in the format defined in
 	// time.ParseDuration. E.g. "300ms,1.5h,2h45m".
 	githubAPITriesProperty = gonfigure.NewEnvProperty("GITHUB_API_TRIES", "0s,10s,30s,3m")
@@ -25,17 +23,11 @@ type Config struct {
 	Port               int
 	AccessToken        string
 	Secret             string
-	GithubAPIDelay     time.Duration
 	GithubAPITryDeltas []time.Duration
 }
 
 func NewConfig() Config {
 	port, err := strconv.Atoi(portProperty.Value())
-	if err != nil {
-		panic(err)
-	}
-
-	githubAPIDelay, err := time.ParseDuration(githubAPIDelayProperty.Value())
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +41,6 @@ func NewConfig() Config {
 		Port:               port,
 		AccessToken:        accessTokenProperty.Value(),
 		Secret:             secretProperty.Value(),
-		GithubAPIDelay:     githubAPIDelay,
 		GithubAPITryDeltas: githubAPITryDeltas,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/deiwin/gonfigure"
@@ -13,13 +15,17 @@ var (
 	secretProperty      = gonfigure.NewRequiredEnvProperty("GITHUB_SECRET")
 	// In the format defined in time.ParseDuration. E.g. "300ms", "-1.5h" or "2h45m".
 	githubAPIDelayProperty = gonfigure.NewEnvProperty("GITHUB_API_DELAY", "2s")
+	// A comma separated list of durations in the format defined in
+	// time.ParseDuration. E.g. "300ms,1.5h,2h45m".
+	githubAPITriesProperty = gonfigure.NewEnvProperty("GITHUB_API_TRIES", "0s,10s,30s,3m")
 )
 
 type Config struct {
-	Port           int
-	AccessToken    string
-	Secret         string
-	GithubAPIDelay time.Duration
+	Port               int
+	AccessToken        string
+	Secret             string
+	GithubAPIDelay     time.Duration
+	GithubAPITryDeltas []time.Duration
 }
 
 func NewConfig() Config {
@@ -34,9 +40,33 @@ func NewConfig() Config {
 	}
 
 	return Config{
-		Port:           port,
-		AccessToken:    accessTokenProperty.Value(),
-		Secret:         secretProperty.Value(),
-		GithubAPIDelay: githubAPIDelay,
+		Port:               port,
+		AccessToken:        accessTokenProperty.Value(),
+		Secret:             secretProperty.Value(),
+		GithubAPIDelay:     githubAPIDelay,
+		GithubAPITryDeltas: getDeltasFromDurationsString(githubAPITriesProperty.Value()),
 	}
+}
+
+func getDeltasFromDurationsString(durationsString string) []time.Duration {
+	durationStringList := strings.Split(durationsString, ",")
+	durationList := make([]time.Duration, len(durationStringList))
+	for i, durationString := range durationStringList {
+		var err error
+		durationList[i], err = time.ParseDuration(durationString)
+		if err != nil {
+			panic(err)
+		}
+	}
+	sort.Slice(durationList, func(i, j int) bool { return durationList[i] < durationList[j] })
+
+	deltas := make([]time.Duration, len(durationList))
+	for i, duration := range durationList {
+		if i == 0 {
+			deltas[i] = duration
+		} else {
+			deltas[i] = duration - durationList[i-1]
+		}
+	}
+	return deltas
 }

--- a/config_test.go
+++ b/config_test.go
@@ -101,42 +101,6 @@ var _ = Describe("Config", func() {
 		})
 	})
 
-	Describe("GITHUB_API_DELAY", func() {
-		name := "GITHUB_API_DELAY"
-
-		Context("when set", func() {
-			duration := "2m"
-			setEnvVars(requiredEnvVars)
-			setEnvVar(envVar{name: name, value: duration})
-
-			It("is passed as a duration", func() {
-				conf := grh.NewConfig()
-				Expect(conf.GithubAPIDelay).To(Equal(2 * time.Minute))
-			})
-		})
-
-		Context("when not a valid duration", func() {
-			duration := "two minutes"
-			setEnvVars(requiredEnvVars)
-			setEnvVar(envVar{name: name, value: duration})
-
-			It("panics", func() {
-				Expect(func() {
-					grh.NewConfig()
-				}).To(Panic())
-			})
-		})
-
-		Context("when not set", func() {
-			setEnvVars(requiredEnvVars)
-
-			It("defaults to a value", func() {
-				conf := grh.NewConfig()
-				Expect(conf.GithubAPIDelay).NotTo(BeNil())
-			})
-		})
-	})
-
 	Describe("GITHUB_API_TRIES", func() {
 		name := "GITHUB_API_TRIES"
 

--- a/config_test.go
+++ b/config_test.go
@@ -136,6 +136,87 @@ var _ = Describe("Config", func() {
 			})
 		})
 	})
+
+	Describe("GITHUB_API_TRIES", func() {
+		name := "GITHUB_API_TRIES"
+
+		Context("when set to sorted durations", func() {
+			durationsString := "0s,2m,2h,4h"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: durationsString})
+
+			It("is passed as an array of duration deltas", func() {
+				conf := grh.NewConfig()
+				Expect(conf.GithubAPITryDeltas).To(Equal([]time.Duration{
+					0,
+					2 * time.Minute,
+					time.Hour + 58*time.Minute,
+					2 * time.Hour,
+				}))
+			})
+		})
+
+		Context("when set to unsorted durations", func() {
+			durationsString := "0s,2h,2m,4h"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: durationsString})
+
+			It("is passed as a sorted array of duration deltas", func() {
+				conf := grh.NewConfig()
+				Expect(conf.GithubAPITryDeltas).To(Equal([]time.Duration{
+					0,
+					2 * time.Minute,
+					time.Hour + 58*time.Minute,
+					2 * time.Hour,
+				}))
+			})
+		})
+
+		Context("when contains an invalid duration", func() {
+			durationsString := "two minutes,2h"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: durationsString})
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+
+		Context("when contains an empty duration", func() {
+			durationsString := ",2h"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: durationsString})
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+
+		Context("when contains spaces", func() {
+			durationsString := "2m, 2h"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: durationsString})
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+
+		Context("when not set", func() {
+			setEnvVars(requiredEnvVars)
+
+			It("defaults to a value", func() {
+				conf := grh.NewConfig()
+				Expect(conf.GithubAPITryDeltas).NotTo(BeNil())
+			})
+		})
+	})
 })
 
 var setEnvVar = func(variable envVar) {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,198 @@
+package main_test
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	grh "github.com/salemove/github-review-helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type envVar struct {
+	name  string
+	value string
+}
+
+var _ = Describe("Config", func() {
+	Describe("GITHUB_ACCESS_TOKEN", func() {
+		name := "GITHUB_ACCESS_TOKEN"
+
+		Context("when set", func() {
+			token := "my-github-token"
+			setEnvVars(replaceEnvVarByName(name, token, requiredEnvVars))
+
+			It("is passed as a string", func() {
+				conf := grh.NewConfig()
+				Expect(conf.AccessToken).To(Equal(token))
+			})
+		})
+
+		Context("when not set", func() {
+			setEnvVars(omitEnvVarByName(name, requiredEnvVars))
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+	})
+
+	Describe("GITHUB_SECRET", func() {
+		name := "GITHUB_SECRET"
+
+		Context("when set", func() {
+			secret := "my-github-secret"
+			setEnvVars(replaceEnvVarByName(name, secret, requiredEnvVars))
+
+			It("is passed as a string", func() {
+				conf := grh.NewConfig()
+				Expect(conf.Secret).To(Equal(secret))
+			})
+		})
+
+		Context("when not set", func() {
+			setEnvVars(omitEnvVarByName(name, requiredEnvVars))
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+	})
+
+	Describe("PORT", func() {
+		name := "PORT"
+
+		Context("when set", func() {
+			port := "1337"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: port})
+
+			It("is passed as an int", func() {
+				conf := grh.NewConfig()
+				Expect(conf.Port).To(Equal(1337))
+			})
+		})
+
+		Context("when not a number", func() {
+			port := "leet"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: port})
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+
+		Context("when not set", func() {
+			setEnvVars(requiredEnvVars)
+
+			It("defaults to a value", func() {
+				conf := grh.NewConfig()
+				Expect(conf.Port).NotTo(BeNil())
+			})
+		})
+	})
+
+	Describe("GITHUB_API_DELAY", func() {
+		name := "GITHUB_API_DELAY"
+
+		Context("when set", func() {
+			duration := "2m"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: duration})
+
+			It("is passed as a duration", func() {
+				conf := grh.NewConfig()
+				Expect(conf.GithubAPIDelay).To(Equal(2 * time.Minute))
+			})
+		})
+
+		Context("when not a valid duration", func() {
+			duration := "two minutes"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: duration})
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+
+		Context("when not set", func() {
+			setEnvVars(requiredEnvVars)
+
+			It("defaults to a value", func() {
+				conf := grh.NewConfig()
+				Expect(conf.GithubAPIDelay).NotTo(BeNil())
+			})
+		})
+	})
+})
+
+var setEnvVar = func(variable envVar) {
+	var (
+		previousValue       string
+		previousValueWasSet bool
+	)
+
+	BeforeEach(func() {
+		previousValue, previousValueWasSet = os.LookupEnv(variable.name)
+		err := os.Setenv(variable.name, variable.value)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	AfterEach(func() {
+		if previousValueWasSet {
+			err := os.Setenv(variable.name, previousValue)
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			err := os.Unsetenv(variable.name)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+}
+
+var setEnvVars = func(vars []envVar) {
+	for _, variable := range vars {
+		setEnvVar(variable)
+	}
+}
+
+var requiredEnvVars = []envVar{
+	{name: "GITHUB_ACCESS_TOKEN", value: "token"},
+	{name: "GITHUB_SECRET", value: "secret"},
+}
+
+var replaceEnvVarByName = func(nameToReplace, newValue string, vars []envVar) []envVar {
+	newVars := make([]envVar, len(vars))
+	indexReplaced := -1
+	for i, variable := range vars {
+		if variable.name == nameToReplace {
+			newVars[i] = envVar{name: nameToReplace, value: newValue}
+			indexReplaced = i
+		} else {
+			newVars[i] = variable
+		}
+	}
+	if indexReplaced == -1 {
+		panic(fmt.Sprintf("Couldn't find env var %s in %v", nameToReplace, vars))
+	}
+
+	return newVars
+}
+
+// omitEnvVarByName "omits" env variables from the list by setting their value
+// to an empty string. This will look as if the value has not been set (or has
+// been set to an empty string) even if the value exists in the env outside of
+// this test run.
+var omitEnvVarByName = func(nameToOmit string, vars []envVar) []envVar {
+	return replaceEnvVarByName(nameToOmit, "", vars)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -208,6 +208,18 @@ var _ = Describe("Config", func() {
 			})
 		})
 
+		Context("when contains negative durations", func() {
+			durationsString := "2m,2h,-2h"
+			setEnvVars(requiredEnvVars)
+			setEnvVar(envVar{name: name, value: durationsString})
+
+			It("panics", func() {
+				Expect(func() {
+					grh.NewConfig()
+				}).To(Panic())
+			})
+		})
+
 		Context("when not set", func() {
 			setEnvVars(requiredEnvVars)
 

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/go-github/github"
 	grh "github.com/salemove/github-review-helper"
@@ -34,6 +35,7 @@ const (
 	issueNumber          = 7
 	arbitraryIssueAuthor = "author"
 	arbitrarySHA         = "1afdea0acb09ff392fcdb89acfa9d7e9feac4bc1"
+	numberOfGithubTries  = 4
 )
 
 var (
@@ -104,9 +106,16 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 
 			*responseRecorder = httptest.NewRecorder()
 
-			conf = grh.Config{
-				Secret: "a-secret",
+			githubAPITryDeltas := make([]time.Duration, numberOfGithubTries)
+			for i := range githubAPITryDeltas {
+				// Try every 1ms
+				githubAPITryDeltas[i] = time.Millisecond
 			}
+			conf = grh.Config{
+				Secret:             "a-secret",
+				GithubAPITryDeltas: githubAPITryDeltas,
+			}
+
 			asyncOperationWg = &sync.WaitGroup{}
 			*handler = grh.CreateHandler(conf, *gitRepos, asyncOperationWg, *pullRequests,
 				*repositories, *issues, *search)

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -270,11 +270,11 @@ var githubCommits = func(commitList ...commit) []*github.RepositoryCommit {
 		}
 		if i > 0 {
 			githubCommitList[i].Parents = []github.Commit{
-				github.Commit{SHA: githubCommitList[i-1].SHA},
+				{SHA: githubCommitList[i-1].SHA},
 			}
 		} else {
 			githubCommitList[i].Parents = []github.Commit{
-				github.Commit{SHA: github.String(arbitraryParentSHA)},
+				{SHA: github.String(arbitraryParentSHA)},
 			}
 		}
 	}
@@ -298,7 +298,7 @@ var mockListCommits = func(commits []*github.RepositoryCommit, perPage int, repo
 	for {
 		pageStartIndex := (pageNumber - 1) * perPage
 		if len(commits) <= pageNumber*perPage {
-			commitsOnThisPage := commits[pageStartIndex:len(commits)]
+			commitsOnThisPage := commits[pageStartIndex:]
 			pullRequests.
 				On("ListCommits", anyContext, repositoryOwner, repositoryName, issueNumber, &github.ListOptions{
 					Page:    pageNumber,

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -108,8 +108,13 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 
 			githubAPITryDeltas := make([]time.Duration, numberOfGithubTries)
 			for i := range githubAPITryDeltas {
-				// Try every 1ms
-				githubAPITryDeltas[i] = time.Millisecond
+				if i == 0 {
+					// Allow the first try to be synchronous
+					githubAPITryDeltas[i] = 0
+				} else {
+					// Try every 1ms
+					githubAPITryDeltas[i] = time.Millisecond
+				}
 			}
 			conf = grh.Config{
 				Secret:             "a-secret",

--- a/main.go
+++ b/main.go
@@ -118,11 +118,13 @@ func handleStatusEvent(body []byte, conf Config, asyncOperationWg *sync.WaitGrou
 	if err != nil {
 		return ErrorResponse{err, http.StatusInternalServerError, "Failed to parse the request's body"}
 	} else if newPullRequestsPossiblyReadyForMerging(statusEvent) {
-		err = delayWithRetries(conf.GithubAPITryDeltas, func() asyncResponse {
+		maybeSyncResponse, err := delayWithRetries(conf.GithubAPITryDeltas, func() asyncResponse {
 			return mergePullRequestsReadyForMerging(statusEvent, gitRepos, search, issues, pullRequests)
 		}, asyncOperationWg)
 		if err != nil {
 			return ErrorResponse{err, http.StatusInternalServerError, "Failed to schedule mergeable PR check"}
+		} else if maybeSyncResponse.OperationFinishedSynchronously {
+			return maybeSyncResponse.Response
 		}
 		return SuccessResponse{"Status update might have caused a PR to become mergeable. Will check for " +
 			"mergeable PRs asynchronously"}

--- a/main.go
+++ b/main.go
@@ -118,8 +118,9 @@ func handleStatusEvent(body []byte, conf Config, asyncOperationWg *sync.WaitGrou
 	if err != nil {
 		return ErrorResponse{err, http.StatusInternalServerError, "Failed to parse the request's body"}
 	} else if newPullRequestsPossiblyReadyForMerging(statusEvent) {
-		delay(conf.GithubAPIDelay, func() Response {
-			return mergePullRequestsReadyForMerging(statusEvent, gitRepos, search, issues, pullRequests)
+		delay(conf.GithubAPIDelay, func() {
+			response := mergePullRequestsReadyForMerging(statusEvent, gitRepos, search, issues, pullRequests)
+			handleAsyncResponse(response)
 		}, asyncOperationWg)
 		return SuccessResponse{
 			fmt.Sprintf("Status update might have caused a PR to become mergeable. Scheduled an operation "+

--- a/main.go
+++ b/main.go
@@ -118,14 +118,14 @@ func handleStatusEvent(body []byte, conf Config, asyncOperationWg *sync.WaitGrou
 	if err != nil {
 		return ErrorResponse{err, http.StatusInternalServerError, "Failed to parse the request's body"}
 	} else if newPullRequestsPossiblyReadyForMerging(statusEvent) {
-		delay(conf.GithubAPIDelay, func() {
-			response := mergePullRequestsReadyForMerging(statusEvent, gitRepos, search, issues, pullRequests)
-			handleAsyncResponse(response)
+		err = delayWithRetries(conf.GithubAPITryDeltas, func() asyncResponse {
+			return mergePullRequestsReadyForMerging(statusEvent, gitRepos, search, issues, pullRequests)
 		}, asyncOperationWg)
-		return SuccessResponse{
-			fmt.Sprintf("Status update might have caused a PR to become mergeable. Scheduled an operation "+
-				"which will start in %s to check for mergeable PRs.", conf.GithubAPIDelay.String()),
+		if err != nil {
+			return ErrorResponse{err, http.StatusInternalServerError, "Failed to schedule mergeable PR check"}
 		}
+		return SuccessResponse{"Status update might have caused a PR to become mergeable. Will check for " +
+			"mergeable PRs asynchronously"}
 	}
 	return SuccessResponse{"Status update does not affect any PRs mergeability. Ignoring."}
 }

--- a/main.go
+++ b/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
-	"os/signal"
 	"sync"
 	"time"
 
@@ -190,28 +188,4 @@ func checkUserAuthorization(issueComment IssueComment, issues Issues, repositori
 			" Responded with a comment. Ignoring the command."}, nil
 	}
 	return nil, nil
-}
-
-func delay(duration time.Duration, operation func() Response, asyncOperationWg *sync.WaitGroup) {
-	interruptChan := make(chan os.Signal, 1)
-	signal.Notify(interruptChan, os.Interrupt)
-
-	timer := time.NewTimer(duration)
-
-	asyncOperationWg.Add(1)
-	go func() {
-		defer asyncOperationWg.Done()
-		// Avoid leaking channels
-		defer signal.Stop(interruptChan)
-
-		// Block until either of the 2 channels receives.
-		select {
-		case <-interruptChan:
-			log.Println("Received an interrupt signal (SIGINT). Starting a scheduled process immediately.")
-		case <-timer.C:
-		}
-
-		response := operation()
-		handleAsyncResponse(response)
-	}()
 }

--- a/main.go
+++ b/main.go
@@ -123,12 +123,10 @@ func handleStatusEvent(body []byte, conf Config, asyncOperationWg *sync.WaitGrou
 	if err != nil {
 		return ErrorResponse{err, http.StatusInternalServerError, "Failed to parse the request's body"}
 	} else if newPullRequestsPossiblyReadyForMerging(statusEvent) {
-		maybeSyncResponse, err := delayWithRetries(conf.GithubAPITryDeltas, func() asyncResponse {
+		maybeSyncResponse := delayWithRetries(conf.GithubAPITryDeltas, func() asyncResponse {
 			return mergePullRequestsReadyForMerging(statusEvent, gitRepos, search, issues, pullRequests)
 		}, asyncOperationWg)
-		if err != nil {
-			return ErrorResponse{err, http.StatusInternalServerError, "Failed to schedule mergeable PR check"}
-		} else if maybeSyncResponse.OperationFinishedSynchronously {
+		if maybeSyncResponse.OperationFinishedSynchronously {
 			return maybeSyncResponse.Response
 		}
 		return SuccessResponse{"Status update might have caused a PR to become mergeable. Will check for " +

--- a/merge_command.go
+++ b/merge_command.go
@@ -93,7 +93,7 @@ func mergeReadyPR(pr *github.PullRequest, gitRepos git.Repos, issues Issues,
 }
 
 func mergePullRequestsReadyForMerging(statusEvent StatusEvent, gitRepos git.Repos, search Search,
-	issues Issues, pullRequests PullRequests) Response {
+	issues Issues, pullRequests PullRequests) asyncResponse {
 	// Not sure if applying the additional repo:owner/name filter to the query
 	// works for cross-fork PRs, but nothing else has been tested with
 	// cross-fork PRs either so this is left in for now.
@@ -114,9 +114,15 @@ func mergePullRequestsReadyForMerging(statusEvent StatusEvent, gitRepos git.Repo
 	issuesToMerge, err := searchIssues(query, search)
 	if err != nil {
 		message := fmt.Sprintf("Searching for issues with query '%s' failed", query)
-		return ErrorResponse{err, http.StatusBadGateway, message}
+		return asyncResponse{
+			Response:     ErrorResponse{err, http.StatusBadGateway, message},
+			MayBeRetried: false,
+		}
 	} else if len(issuesToMerge) == 0 {
-		return SuccessResponse{"Found no PRs to merge"}
+		return asyncResponse{
+			Response:     SuccessResponse{"Found no PRs to merge"},
+			MayBeRetried: true,
+		}
 	}
 
 	var finalErrResp *ErrorResponse
@@ -149,9 +155,15 @@ func mergePullRequestsReadyForMerging(statusEvent StatusEvent, gitRepos git.Repo
 		}
 	}
 	if finalErrResp != nil {
-		return finalErrResp
+		return asyncResponse{
+			Response:     finalErrResp,
+			MayBeRetried: false,
+		}
 	}
-	return SuccessResponse{fmt.Sprintf("Successfully merged %d PRs", len(issuesToMerge))}
+	return asyncResponse{
+		Response:     SuccessResponse{fmt.Sprintf("Successfully merged %d PRs", len(issuesToMerge))},
+		MayBeRetried: false,
+	}
 }
 
 func containsPendingSquashStatus(statuses []github.RepoStatus) bool {

--- a/merge_command.go
+++ b/merge_command.go
@@ -114,15 +114,9 @@ func mergePullRequestsReadyForMerging(statusEvent StatusEvent, gitRepos git.Repo
 	issuesToMerge, err := searchIssues(query, search)
 	if err != nil {
 		message := fmt.Sprintf("Searching for issues with query '%s' failed", query)
-		return asyncResponse{
-			Response:     ErrorResponse{err, http.StatusBadGateway, message},
-			MayBeRetried: false,
-		}
+		return nonRetriable(ErrorResponse{err, http.StatusBadGateway, message})
 	} else if len(issuesToMerge) == 0 {
-		return asyncResponse{
-			Response:     SuccessResponse{"Found no PRs to merge"},
-			MayBeRetried: true,
-		}
+		return retriable(SuccessResponse{"Found no PRs to merge"})
 	}
 
 	var finalErrResp *ErrorResponse
@@ -155,15 +149,11 @@ func mergePullRequestsReadyForMerging(statusEvent StatusEvent, gitRepos git.Repo
 		}
 	}
 	if finalErrResp != nil {
-		return asyncResponse{
-			Response:     finalErrResp,
-			MayBeRetried: false,
-		}
+		return nonRetriable(finalErrResp)
 	}
-	return asyncResponse{
-		Response:     SuccessResponse{fmt.Sprintf("Successfully merged %d PRs", len(issuesToMerge))},
-		MayBeRetried: false,
-	}
+	return nonRetriable(
+		SuccessResponse{fmt.Sprintf("Successfully merged %d PRs", len(issuesToMerge))},
+	)
 }
 
 func containsPendingSquashStatus(statuses []github.RepoStatus) bool {

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -130,9 +130,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 					})
 
-					It("tries once", func() {
+					It("tries the configured amount of times", func() {
 						handle()
-						search.AssertNumberOfCalls(GinkgoT(), "Issues", 1)
+						search.AssertNumberOfCalls(GinkgoT(), "Issues", numberOfGithubTries)
 					})
 				})
 

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -46,7 +46,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 		for _, badStatus := range []string{"pending", "failure", "error"} {
 			Context("with "+badStatus+" status", func() {
-				branches := []grh.Branch{grh.Branch{
+				branches := []grh.Branch{{
 					SHA: mockSHA,
 				}}
 
@@ -66,7 +66,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 			Context("when updating a commit that is not a branch's head", func() {
 				otherSHA := "4eaf26faa8819ab5aee991461b8c4fff41778f41"
-				branches := []grh.Branch{grh.Branch{
+				branches := []grh.Branch{{
 					SHA: otherSHA,
 				}}
 
@@ -81,7 +81,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			})
 
 			Context("when updating a commit that is a branch's head", func() {
-				branches := []grh.Branch{grh.Branch{
+				branches := []grh.Branch{{
 					SHA: mockSHA,
 				}}
 
@@ -133,7 +133,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					BeforeEach(func() {
 						searchResult := &github.IssuesSearchResult{
 							Total: github.Int(1),
-							Issues: []github.Issue{github.Issue{
+							Issues: []github.Issue{{
 								Number: github.Int(issueNumber),
 								User: &github.User{
 									Login: github.String(userName),
@@ -245,7 +245,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					BeforeEach(func() {
 						firstPageSearchResult := &github.IssuesSearchResult{
 							Total: github.Int(1),
-							Issues: []github.Issue{github.Issue{
+							Issues: []github.Issue{{
 								Number: github.Int(firstIssueNumber),
 								User: &github.User{
 									Login: github.String(firstAuthor),
@@ -254,7 +254,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						}
 						secondPageSearchResult := &github.IssuesSearchResult{
 							Total: github.Int(1),
-							Issues: []github.Issue{github.Issue{
+							Issues: []github.Issue{{
 								Number: github.Int(secondIssueNumber),
 								User: &github.User{
 									Login: github.String(secondAuthor),

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -109,6 +109,11 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						handle()
 						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 					})
+
+					It("tries once", func() {
+						handle()
+						search.AssertNumberOfCalls(GinkgoT(), "Issues", 1)
+					})
 				})
 
 				Context("with issue search return 0 PRs", func() {
@@ -123,6 +128,11 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 					It("returns 200 OK", func() {
 						handle()
 						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+					})
+
+					It("tries once", func() {
+						handle()
+						search.AssertNumberOfCalls(GinkgoT(), "Issues", 1)
 					})
 				})
 
@@ -155,6 +165,11 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						It("returns 200 OK", func() {
 							handle()
 							Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+						})
+
+						It("tries once", func() {
+							handle()
+							search.AssertNumberOfCalls(GinkgoT(), "Issues", 1)
 						})
 					})
 

--- a/merge_command_state_update_test.go
+++ b/merge_command_state_update_test.go
@@ -103,11 +103,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						mockSearchQuery(1).Return(emptyResult, emptyResponse, errors.New("arbitrary error"))
 					})
 
-					// async errors are logged, but won't affect the outcome of
-					// the HTTP request
-					It("returns 200 OK", func() {
+					It("fails with a gateway error", func() {
 						handle()
-						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+						Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 					})
 
 					It("tries once", func() {
@@ -160,11 +158,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								Return(emptyResult, emptyResponse, errArbitrary)
 						})
 
-						// async errors are logged, but won't affect the outcome of
-						// the HTTP request
-						It("returns 200 OK", func() {
+						It("fails with a gateway error", func() {
 							handle()
-							Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+							Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 						})
 
 						It("tries once", func() {
@@ -195,8 +191,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								Return(pr, emptyResponse, noError)
 						})
 
-						isAsync := true
-						ItMergesPR(context, pr, isAsync)
+						ItMergesPR(context, pr)
 					})
 				})
 

--- a/merge_command_test.go
+++ b/merge_command_test.go
@@ -218,7 +218,7 @@ func commentMentioning(user string) func(issueComment *github.IssueComment) bool
 	}
 }
 
-var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts ...bool) {
+var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 	var (
 		handle = context.Handle
 
@@ -230,11 +230,6 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 		issueAuthor string
 		issueNumber int
 		headRef     string
-
-		// async errors are logged, but won't affect the outcome of the HTTP
-		// request. The tests can only confirm that the right stubs were called
-		// for async operations.
-		isAsync bool
 	)
 	BeforeEach(func() {
 		responseRecorder = *context.ResponseRecorder
@@ -245,12 +240,6 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 		issueAuthor = *pr.User.Login
 		issueNumber = *pr.Number
 		headRef = *pr.Head.Ref
-
-		if len(opts) == 0 {
-			isAsync = false
-		} else {
-			isAsync = opts[0]
-		}
 	})
 
 	Context("with merge failing with an unknown error", func() {
@@ -272,11 +261,7 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 
 		It("fails with a gateway error", func() {
 			handle()
-			if isAsync {
-				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
-			} else {
-				Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
-			}
+			Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 		})
 	})
 
@@ -323,11 +308,7 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 					Return(emptyResult, emptyResponse, noError)
 
 				handle()
-				if isAsync {
-					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
-				} else {
-					Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
-				}
+				Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 			})
 
 			Context("with author notification failing", func() {
@@ -340,11 +321,7 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 
 				It("fails with a gateway error", func() {
 					handle()
-					if isAsync {
-						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
-					} else {
-						Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
-					}
+					Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 				})
 			})
 		})
@@ -392,11 +369,7 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 
 		It("fails with a gateway error", func() {
 			handle()
-			if isAsync {
-				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
-			} else {
-				Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
-			}
+			Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 		})
 	})
 
@@ -428,11 +401,7 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 
 			It("fails with a gateway error", func() {
 				handle()
-				if isAsync {
-					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
-				} else {
-					Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
-				}
+				Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
 			})
 		})
 
@@ -453,11 +422,7 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 
 				It("fails with an internal error", func() {
 					handle()
-					if isAsync {
-						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
-					} else {
-						Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
-					}
+					Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
 				})
 			})
 
@@ -478,11 +443,7 @@ var ItMergesPR = func(context WebhookTestContext, pr *github.PullRequest, opts .
 
 					It("fails with an internal error", func() {
 						handle()
-						if isAsync {
-							Expect(responseRecorder.Code).To(Equal(http.StatusOK))
-						} else {
-							Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
-						}
+						Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
 					})
 				})
 

--- a/merge_command_test.go
+++ b/merge_command_test.go
@@ -168,7 +168,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								Return(&github.CombinedStatus{
 									State: github.String("pending"),
 									Statuses: []github.RepoStatus{
-										github.RepoStatus{
+										{
 											Context: github.String("jenkins/pr"),
 											State:   github.String("success"),
 										},
@@ -184,7 +184,7 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 								Return(&github.CombinedStatus{
 									State: github.String("pending"),
 									Statuses: []github.RepoStatus{
-										github.RepoStatus{
+										{
 											Context: github.String("review/squash"),
 											State:   github.String("pending"),
 										},

--- a/pull_request_event_test.go
+++ b/pull_request_event_test.go
@@ -79,15 +79,15 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 							Return(emptyResult, resp, err)
 					})
 
-					It("fails with a gateway error", func() {
+					// Responds with 200, because the operation will be retries asynchronously
+					It("responds with 200 OK", func() {
 						handle()
-						Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 					})
 
-					It("tries multiple times", func() {
+					It("tries the configured amount of times", func() {
 						handle()
-						// +1 because of the initial attempt
-						pullRequests.AssertNumberOfCalls(GinkgoT(), "ListCommits", grh.GetCommitsRetryLimit+1)
+						pullRequests.AssertNumberOfCalls(GinkgoT(), "ListCommits", numberOfGithubTries)
 					})
 				})
 
@@ -122,15 +122,15 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						), emptyResponse, noError)
 				})
 
-				It("fails with a gateway error", func() {
+				// Responds with 200, because the operation will be retries asynchronously
+				It("responds with 200 OK", func() {
 					handle()
-					Expect(responseRecorder.Code).To(Equal(http.StatusBadGateway))
+					Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 				})
 
-				It("tries multiple times", func() {
+				It("tries the configured amount of times", func() {
 					handle()
-					// +1 because of the initial attempt
-					pullRequests.AssertNumberOfCalls(GinkgoT(), "ListCommits", grh.GetCommitsRetryLimit+1)
+					pullRequests.AssertNumberOfCalls(GinkgoT(), "ListCommits", numberOfGithubTries)
 				})
 			})
 

--- a/squash.go
+++ b/squash.go
@@ -61,7 +61,7 @@ func checkForFixupCommits(issueable Issueable, isExpectedHead func(string) bool,
 	conf Config, asyncOperationWg *sync.WaitGroup) Response {
 
 	log.Printf("Checking for fixup commits for PR %s.\n", issueable.Issue().FullName())
-	maybeSyncResponse, err := delayWithRetries(conf.GithubAPITryDeltas, func() asyncResponse {
+	maybeSyncResponse := delayWithRetries(conf.GithubAPITryDeltas, func() asyncResponse {
 		commits, asyncErrResp := getCommits(issueable, isExpectedHead, pullRequests)
 		if asyncErrResp != nil {
 			return asyncErrResp.toAsyncResponse()
@@ -79,9 +79,7 @@ func checkForFixupCommits(issueable Issueable, isExpectedHead func(string) bool,
 		}
 		return nonRetriable(SuccessResponse{})
 	}, asyncOperationWg)
-	if err != nil {
-		return ErrorResponse{err, http.StatusInternalServerError, "Failed to schedule checking for fixup commits"}
-	} else if maybeSyncResponse.OperationFinishedSynchronously {
+	if maybeSyncResponse.OperationFinishedSynchronously {
 		return maybeSyncResponse.Response
 	}
 	return SuccessResponse{fmt.Sprintf(


### PR DESCRIPTION
This (somewhat large) PR gets rid of the current biggest pain-point of github-review-helper: GitHub API's eventual consistency causing various operations to fail, even if those operations are retried synchronously multiple times.

This PR allows known problematic operations to be tried according to a configurable schedule. By default the schedule is `"0s,10s,30s,3m"`, which means the operation will first be tried synchronously, then when there's reason to believe that the response isn't up to date then the operation will be retried after 10 seconds, then again 30s after the initial try, and so on.

The schedule is currently applied to 2 operations: 1) issue search that checks whether a PR has become mergeable after a status update, and 2) getting the list of commits for a PR.