### PR TITLE
Add introductory/explanatory articles

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,0 +1,135 @@
+# Improving GitHub reviews with fixup commits and a helpful bot
+
+_github-review-helper_ is a tool that aims, as the name implies, to improve the
+GitHub PR review workflow. This document explains what exactly do GitHub PRs
+need help with and how _github-review-helper_ addresses those problems.
+
+## The problem
+
+Let's imagine Alice and Bob working together on a software project. Let's
+further imagine that Alice has just managed to track down and fix a bug that's
+been troubling them both for a while. Proud of her achievement, Alice commits
+her changes, creates a PR, and asks Bob to give it a look, assigning him as the
+reviewer.
+
+Bob, ever so observant, notices that one of the tests that Alice has added
+couldn't possibly pass. He leaves a comment pointing out the issue and
+suggesting a solution. Few moments later their helpful CI also chimes in,
+notifying of the test failure by leaving a little red cross on the PR.
+
+Now, the problem lies in the question of how Alice should proceed from here?
+Most teams/projects have adopted one of the following practices.
+
+- Alice adds another commit to the PR, named "Fix tests". The PR will later be
+  merged to master and that "Fix tests" commit will be reachable from master.
+- Alice again adds a "Fix tests" commit to the PR, but when the PR is ready to
+  be merged it is first squashed into a single commit and only then merged.
+- Alice changes the commit that introduced the issue, amending the commit to
+  include her test fixes.
+
+All three approaches have their merits and problems. Let's go through all of
+them one by one.
+
+**Adding a new commit that will later be merged to master.**
+
+We believe that in order to collaborate effectively, all commits that get
+merged into master should follow a few basic [rules][0]. One of these rules
+states that commits should be [complete][1]. Having changes that break a test
+and changes that fix that test in two separate commits breaks that rule. When
+this rule is broken, then cherry-picking or reverting the change becomes much
+more difficult and tracking down bugs also becomes more difficult, because
+tools like `git bisect` might not work as expected. In addition, usage of `git
+blame` becomes a lot more tedious when this rule is broken often, because
+related changes can not be expected to have come from the same commit.
+
+**Adding a new commit that will be squashed before merging into master.**
+
+This approach has gained popularity since GitHub added this option to their PR
+merge button. And it does avoid the problem of completeness introduced by the
+previous approach, but it has it's own problems. When a PR is very small, then
+this approach actually works amazingly well. It breaks down, however, when a PR
+has a bit more going on. Its main problem is that it breaks the rule which
+states that commits should be [focused][2], they should only do _one thing_ (a
+specialization of the more general Single Responsibility Principle). Following
+this rule makes the use of `git blame` a joy and PR reviews productive. Both
+benefits which will be lost when the rule is broken, as it would be with a
+squash. Furthermore, a lot of valuable context and documentation (that
+[hopefully][3] was included in the commit message) can be lost with the squash.
+
+**Amending the original commit.**
+
+This approach requires the contributors to a project to be a bit more familiar
+with git than the previous approaches, but the commits that will eventually be
+merged to master will be void of the problems caused by the previous two
+approaches. With this approach, commits can be kept both complete and focused
+on a single thing, which makes this approach the preferred solution for many
+teams where the members are reasonably comfortable with git. But this approach
+is also not without flaws. It sometimes makes it very hard to answer the
+question that comes up often in PR reviews: "What exactly did you change?"
+Coming back to our example with Alice and Bob, if Alice were to use this
+approach, then after she pushes the new version of her commits, that is all
+that Bob will see. He will not be able to compare the new version of the PR to
+the old (pre-review) version, neither will he be able to see what exactly did
+Alice change in response to his comments.
+
+This problem of not being able to see a PR's evolution is not something that's
+easily noticed, unless one has worked with other tools that do provide this
+visibility.
+
+## A solution
+
+Inspired by how other tools, such as [Gerrit][4], for example, manage to avoid
+the issues described above, _github-review-helper_ was built to solve this
+problem without requiring its users to leave the GitHub platform. What
+_github-review-helper_ essentially does is it combines the three approaches
+described above. It does so in such a way that we get to keep the benefits of
+every approach while leaving behind their downsides. It manages to do so at the
+cost of a little added complexity.
+
+Let's see how it works by revisiting our example, with Alice and Bob using
+ _github-review-helper_ this time around.
+
+Once Alice has locally fixed the issue with the tests, she will then put these
+test fixes into a fixup commit. A fixup commit is like any other commit, except
+it has a very specific title, which will refer to another commit. Alice will
+create the fixup commit so that it will refer to the original commit that broke
+the test. She will then push her changes and ask Bob to review the PR again.
+Notice that at this point the workflow has been very similar to the first two
+approaches described above, except that instead of the commit's title being
+"Fix tests", it'll now be something like "fixup! Fix annoying bug".
+
+Now when Bob looks at the PR again, he can see all the changes that Alice made
+after the initial review by looking at the fixup commit's diff. He likes the
+way Alice has chosen to fix the tests and because he is just as anxious as
+Alice is to get this bug fixed, he quickly approves the PR.
+
+With the PR approved and CI checks passing, it is almost ready to be merged.
+But we don't want to simply merge it as-is, because that would also merge the
+fixup commit into master which is problematic for all the reasons previously
+discussed. In fact, if the repository is properly configured, Alice will not
+_be able_ to merge the PR if it includes any fixup commits. So now, instead of
+clicking the merge button on the PR, Alice will write a comment that says just
+"!merge". She will then see how the "Fix annoying bug" and "fixup! Fix annoying
+bug" commits are squashed into a single "Fix annoying bug" commit, while all
+other commits remain intact. Then, once the CI finishes re-checking the PR
+after the squash, Alice sees that the PR is automatically merged.
+
+## Onward
+
+If you feel like you or your team is affected by this problem, then briefly
+read up about [fixup commits][5] if you need to and head over to the
+[readme](../README.md) for instructions on setting up _github-review-helper_
+for your own project.
+
+And if you feel like you are affected by this problem, but don't like the
+solution provided here, then don't despair - there's plenty of other, more
+comprehensive solutions out there. Check out [Reviewable][6] and [Gerrit][4],
+for example.
+
+[0]: rules.md
+[1]: rules.md#complete
+[2]: rules.md#focused
+[3]: rules.md#context-providing
+[4]: https://www.gerritcodereview.com/
+[5]: https://git-scm.com/docs/git-commit#git-commit---fixupltcommitgt
+[6]: https://reviewable.io/

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -1,0 +1,160 @@
+# Four rules for effective collaboration
+
+Whether you're working in a large team or solo, effective collaboration is
+predicated upon keeping a clean version control history. (Yes, dealing with
+your own past follies also counts as collaboration.) Here we'll consider a
+clean history to be one in which commits are _Conventional_,
+_Context-Providing_, _Complete_, and _Focused_. Each of these four rules (or
+guidelines) is described in detail below.
+
+It is important to note that these rules only apply for commits that are shared
+and/or eventually merged into a stable branch (usually master). But this is not
+the only situation in which commits can be used - quick and dirty commits are
+very helpful when considered as drafts. These rules are not meant to dissuade
+one from committing early and committing often. During the early divergent
+phase of problem solving, when many different approaches are considered,
+following these rules would only inhibit the creative process.
+
+## The rules
+
+### Conventional
+
+**Every commit message should follow the conventions of its project.**
+
+There are a [few very basic conventions][0] that almost every project follows,
+but the specifics vary greatly from project to project. What's important, is to
+follow whatever conventions have been agreed upon. Are all commit titles (the
+first line of the commit message) in the project in imperative mood? Every new
+title should also be in the imperative mood. Are commit titles prefixed by the
+general nature of the change (e.g. documentation/bug/feature/refactoring)?
+Every new commit should also have the prefix.
+
+### Context-Providing
+
+**Every commit message should explain the commit's reason for being.**
+
+The message should provide (within reason) all possible context for the commit.
+Here are some of the questions that the message should answer:
+
+- Why is this change necessary?
+- What assumptions is it based on?
+- Were any alternative solutions considered?
+- Why was this solution chosen from among the alternatives?
+- Are there any non-obvious implications that this change has?
+
+References to other relevant information may be included. Some examples:
+
+- A ref to another commit. E.g. a bug fix may refer to the commit that
+  introduced the bug for providing additional context. Usually the abbreviated
+  SHA (e.g. `c71598f`) of the commit is sufficient, but more comprehensive
+  styles, such as the [one used for git itself][1], can be considered.
+- Link to library/language or any other documentation. Often it also makes
+  sense to actually quote the most relevant bits within the message as well, to
+  avoid losing the context when the link stops working.
+- Link or a reference to the relevant ticket/issue for which this commit was
+  created.
+
+### Complete
+
+**Every commit should be complete.**
+
+This means that every commit should leave the system in a state where: 1) the
+code compiles, 2) its tests pass (note that requiring end-to-end tests to pass
+isn't always reasonable, but lower level tests should always pass), and 3) the
+linter does not complain. This means, for example, that a bug fix and the
+related test changes should be in the same commit.
+
+### Focused
+
+**Every commit should only do a _single thing_.**
+
+What this means precisely is often arguable, but what it means in general is
+usually well understood. For example, refactoring should be separate from an
+addition of a feature. Formatting changes should be separate from bug fixes. A
+commit should only fix a single bug at a time, not two or three.
+
+Note that keeping commits _Complete_ forces one towards bigger (less in terms
+of lines and more in terms of logical changes) commits, whereas keeping them
+_Focused_ pushes towards smaller commits. This is so because essentially
+they're different perspectives or gages for reaching the same ultimate goal -
+having a commit that does just enough and not a bit more.
+
+## Benefits
+
+The benefits are best illustrated by looking at different phases or processes
+of development and seeing how following the specific rules affects that
+phase/process.
+
+### Code review
+
+**_Conventional_** commits are easy to grasp at a glance. Without having to
+know the idiosyncrasies of the author, it is usually clear, in broad terms,
+what the commit does. Just by looking at its title. Also, _Conventional_ commit
+messages should never break the tooling. E.g. if a commit message's body is not
+wrapped at the recommended 72 characters, then the message becomes hard to read
+both on GitHub and in the terminal.
+
+**_Context-Providing_** commits are just a joy to review. The author has
+already answered the most likely questions the reviewer might think of while
+looking at the diff. This reduces a lot of time consuming back-and-forth. In
+addition, if the commit does not provide enough context, then often reviewers
+may feel overwhelmed by the change and only check it for syntax errors and
+typos, without delving into the bigger questions. This way the team might miss
+out on important insights.
+
+**_Complete_** commits minimize the amount of information the reviewer has to
+keep in their head. For example, if a function's interface is changed in one
+commit and its callers are changed in another, then the reviewer must either
+remember how the function was exactly changed, when looking at the callers, or
+they must jump between the two commits. Both options complicate the process and
+lower the chance of catching issues. In addition, when commits are _Complete_,
+the reviewer can compile the code and run the tests to verify the correctness
+of _every_ commit.
+
+**_Focused_** commits often make it possible to review at all, with any sort of
+confidence. If formatting changes are clumped together with a feature addition,
+then important parts of the new feature might be buried in the diff of the dumb
+formatting change and might be missed by the reviewer. If a few bug fixes, a
+new feature, and some refactoring is all in a single commit, then comprehensive
+reviewing is usually impossible and any reviews that the commit does get are
+necessarily shallow.
+
+### Debugging or understanding existing code
+
+This section covers the general concept of understanding already existing (or
+old) code, either for debugging or some other purpose. Most commonly deeper
+understanding is required for debugging purposes, but there are other reasons
+as well. For example, figuring out why a feature was developed in a certain
+way, when implementing something similar in another part of the system. In the
+following text we'll use the word "debugging", but the benefits equally apply
+to the other purposes as well.
+
+**Debugging is very similar to reviewing, so many of the same benefits apply.**
+However, because debugging usually happens a while after the change was made,
+the author may no longer be available or they might not remember the specifics.
+For this reason, it is of paramount importance that the commits be
+**_Context-Providing_**. There just isn't anyone to ask anymore.
+
+Debugging situations also illustrate why it's often (but not always) more
+beneficial to put the context into the commit and not into comments in the
+code. Namely, the code comments might have been changed or deleted by this
+time. And although the original code comments are still available within the
+diff of the commit, if it's not a practice to check the commits for the context
+(which is usually the case, if commits don't provide enough context) then the
+diff will likely not be looked at.
+
+**_Complete_** commits make it possible to use `git bisect`, which may turn out
+to be very helpful for finding the source of certain issues.
+
+## Inspiration and additional reading
+
+- [Guidelines for submitting patches to the git project][2]
+- [Popular commit message conventions][3]
+- [More thoughts on good commit messages][4]
+
+
+[0]: https://git-scm.com/docs/git-commit#_discussion
+[1]: https://github.com/git/git/blob/8b2efe2a0fd93b8721879f796d848a9ce785647f/Documentation/SubmittingPatches#L129-L139
+[2]: https://github.com/git/git/blob/master/Documentation/SubmittingPatches
+[3]: https://chris.beams.io/posts/git-commit/
+[4]: http://who-t.blogspot.com.ee/2009/12/on-commit-messages.html


### PR DESCRIPTION
The purpose of the bot is hard to explain to people who haven't used it.
These articles aim to serialize the main ideas behind it. The rules were
added because they're essentially the guiding principles behind the
bot's existence and it's nice to have them written down as well.