### PR TITLE
Link to intro doc from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![GoDoc](https://godoc.org/github.com/salemove/github-review-helper?status.svg)](https://godoc.org/github.com/salemove/github-review-helper)
 
 ## What?
+
+**See [here](doc/intro.md)** for a high-level introduction.
+
 **github-review-helper** is a little bot that you can set up GitHub hooks for to improve your project's PR review flow.
 It currently does 4 things:
 


### PR DESCRIPTION
People who organically find this repository might still currently have a
hard time understanding what this is about. Linking to the intro article
here might help.

I thought about replacing the readme with the intro, and i don't know if
it's wise, but I'd like to keep the readme more like an actual readme -
with setup instruction etc.