### PR TITLE
Expand !merge command

### DIFF
--- a/authentication_test.go
+++ b/authentication_test.go
@@ -101,6 +101,18 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						Expect(responseRecorder.Body.String()).To(ContainSubstring("Ignoring"))
 					})
 				})
+
+				Context("with a '!mergethis' comment (without space after '!merge')", func() {
+					requestJSON.Is(func() string {
+						return IssueCommentEvent("!mergethis", arbitraryIssueAuthor)
+					})
+
+					It("succeeds with 'ignored' response", func() {
+						handle()
+						Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+						Expect(responseRecorder.Body.String()).To(ContainSubstring("Ignoring"))
+					})
+				})
 			})
 		})
 	})

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/salemove/github-review-helper/mocks"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -18,11 +16,9 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 			requestJSON = context.RequestJSON
 
 			responseRecorder *httptest.ResponseRecorder
-			pullRequests     *mocks.PullRequests
 		)
 		BeforeEach(func() {
 			responseRecorder = *context.ResponseRecorder
-			pullRequests = *context.PullRequests
 		})
 
 		Context("with an empty X-Hub-Signature header", func() {

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"log"
@@ -180,6 +181,10 @@ var TestWebhookHandler = func(test WebhookTest) bool {
 }
 
 var IssueCommentEvent = func(comment, issueAuthor string) string {
+	commentMsg, err := json.Marshal(comment)
+	if err != nil {
+		panic(err)
+	}
 	return `{
   "issue": {
     "number": ` + strconv.Itoa(issueNumber) + `,
@@ -191,7 +196,7 @@ var IssueCommentEvent = func(comment, issueAuthor string) string {
     }
   },
   "comment": {
-    "body": "` + comment + `"
+    "body": ` + string(commentMsg) + `
   },
   "repository": {
     "name": "` + repositoryName + `",

--- a/github_review_helper_suite_test.go
+++ b/github_review_helper_suite_test.go
@@ -40,7 +40,7 @@ const (
 
 var (
 	repository = &github.Repository{
-		ID: github.Int(repositoryID),
+		ID: github.Int64(repositoryID),
 		Owner: &github.User{
 			Login: github.String(repositoryOwner),
 		},

--- a/merge_command.go
+++ b/merge_command.go
@@ -15,7 +15,7 @@ const (
 )
 
 var (
-	mergeCommandPattern = regexp.MustCompile(`^\s*!merge(\s.*)?$`)
+	mergeCommandPattern = regexp.MustCompile(`(?s)^\s*!merge(\s.*)?$`)
 )
 
 func isMergeCommand(comment string) bool {

--- a/merge_command.go
+++ b/merge_command.go
@@ -15,7 +15,7 @@ const (
 )
 
 func isMergeCommand(comment string) bool {
-	return strings.TrimSpace(comment) == "!merge"
+	return strings.HasPrefix(strings.TrimSpace(comment), "!merge")
 }
 
 func newPullRequestsPossiblyReadyForMerging(statusEvent StatusEvent) bool {

--- a/merge_command.go
+++ b/merge_command.go
@@ -15,7 +15,7 @@ const (
 )
 
 var (
-	mergeCommandPattern = regexp.MustCompile(`^\s*!merge.*$`)
+	mergeCommandPattern = regexp.MustCompile(`^\s*!merge(\s.*)?$`)
 )
 
 func isMergeCommand(comment string) bool {

--- a/merge_command.go
+++ b/merge_command.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
+	"regexp"
 
 	"github.com/google/go-github/github"
 	"github.com/salemove/github-review-helper/git"
@@ -14,8 +14,12 @@ const (
 	MergingLabel = "merging"
 )
 
+var (
+	mergeCommandPattern = regexp.MustCompile(`^\s*!merge.*$`)
+)
+
 func isMergeCommand(comment string) bool {
-	return strings.HasPrefix(strings.TrimSpace(comment), "!merge")
+	return mergeCommandPattern.MatchString(comment)
 }
 
 func newPullRequestsPossiblyReadyForMerging(statusEvent StatusEvent) bool {

--- a/merge_command_test.go
+++ b/merge_command_test.go
@@ -205,6 +205,22 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 						})
 
 						ItMergesPR(context, pr)
+
+						Context("with a '!mergethis' comment", func() {
+							requestJSON.Is(func() string {
+								return IssueCommentEvent("!mergethis", issueAuthor)
+							})
+
+							ItMergesPR(context, pr)
+						})
+
+						Context("with a '!merge this' comment", func() {
+							requestJSON.Is(func() string {
+								return IssueCommentEvent("!merge this", issueAuthor)
+							})
+
+							ItMergesPR(context, pr)
+						})
 					})
 				})
 			})

--- a/merge_command_test.go
+++ b/merge_command_test.go
@@ -206,14 +206,6 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 						ItMergesPR(context, pr)
 
-						Context("with a '!mergethis' comment", func() {
-							requestJSON.Is(func() string {
-								return IssueCommentEvent("!mergethis", issueAuthor)
-							})
-
-							ItMergesPR(context, pr)
-						})
-
 						Context("with a '!merge this' comment", func() {
 							requestJSON.Is(func() string {
 								return IssueCommentEvent("!merge this", issueAuthor)

--- a/merge_command_test.go
+++ b/merge_command_test.go
@@ -213,6 +213,14 @@ var _ = TestWebhookHandler(func(context WebhookTestContext) {
 
 							ItMergesPR(context, pr)
 						})
+
+						Context("with a '!merge this' comment with newlines", func() {
+							requestJSON.Is(func() string {
+								return IssueCommentEvent("!merge\n\nthis", issueAuthor)
+							})
+
+							ItMergesPR(context, pr)
+						})
 					})
 				})
 			})

--- a/squash_command_test.go
+++ b/squash_command_test.go
@@ -110,7 +110,7 @@ var ItSquashesPR = func(context WebhookTestContext, pr *github.PullRequest) {
 
 	Context("with autosquash and push failing due to a squash conflict", func() {
 		BeforeEach(func() {
-			squashErr := &git.ErrSquashConflict{errors.New("merge conflict")}
+			squashErr := &git.ErrSquashConflict{Err: errors.New("merge conflict")}
 			gitRepo.
 				On("AutosquashAndPush", "origin/"+baseRef, headSHA, headRef).
 				Return(squashErr)


### PR DESCRIPTION
The reson for this PR is that some applications for mobile phones
(example SwiftHawk for iOS) post an additional line when commenting and
the !merge command gets ignored.

To avoid this kind of behaviour, the logic of finding the merge comment
is changed to search for prefix insead of the whole comment.